### PR TITLE
Minikube based Travis build and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,24 @@
 sudo: required
 
-services:
-  - docker
+language: go
+go:
+- "1.10.x"
 
-before_install:
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y install docker-ce
+env:
+- KUBERNETES_CONFIG_FILE=$HOME/.kube/config CHANGE_MINIKUBE_NONE_USER=true
+
+install:
+- go get -u github.com/golang/dep/cmd/dep
+- cd $GOPATH/src/github.com/nats-io/nats-operator && dep ensure
+
+before_script:
+- go version
+- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+- curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+- sudo minikube start --vm-driver=none --kubernetes-version=v1.9.0
+- minikube update-context
+- JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
 script:
-  - docker build --no-cache -t "nats-io/nats-operator:${TRAVIS_TAG:-latest}" .
-
-after_success:
-  - if ([[ "${TRAVIS_BRANCH}" == "master" ]] && [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]) || [[ "${TRAVIS_TAG}" != "" ]];
-    then
-        docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" quay.io;
-        docker push "nats-io/nats-operator:${TRAVIS_TAG:-latest}";
-    fi
+- kubectl cluster-info 
+- cd $GOPATH/src/github.com/nats-io/nats-operator/test/operator/ && go test ./... -v

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -184,7 +184,7 @@ func run(stop <-chan struct{}) {
 
 	for {
 		c := controller.New(cfg)
-		err := c.Run()
+		err := c.Run(context.TODO())
 		switch err {
 		case controller.ErrVersionOutdated:
 		default:

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -87,7 +88,7 @@ func New(cfg Config) *Controller {
 	}
 }
 
-func (c *Controller) Run() error {
+func (c *Controller) Run(ctx context.Context) error {
 	var (
 		watchVersion string
 		err          error
@@ -128,7 +129,13 @@ func (c *Controller) Run() error {
 			pt.stop()
 		}
 	}()
-	return <-errCh
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	}
 }
 
 func (c *Controller) handleClusterEvent(event *Event) error {

--- a/test/operator/basic_test.go
+++ b/test/operator/basic_test.go
@@ -1,0 +1,121 @@
+package operatortests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/pires/nats-operator/pkg/client"
+	"github.com/pires/nats-operator/pkg/controller"
+	k8scrdclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	k8srestapi "k8s.io/client-go/rest"
+	k8sclientcmd "k8s.io/client-go/tools/clientcmd"
+)
+
+func TestRegisterCRD(t *testing.T) {
+	c, err := newController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Run the operator controller in the background.
+	go func() {
+		err := c.Run(ctx)
+		if err != nil && err != context.Canceled {
+			t.Fatal(err)
+		}
+	}()
+
+	cl, err := newKubeClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Wait for the CRD to be registered in the background.
+	time.Sleep(10 * time.Second)
+
+	// Confirm that the resource has been created.
+	result, err := cl.kcrdc.ApiextensionsV1beta1().
+		CustomResourceDefinitions().
+		Get("natsclusters.nats.io", k8smetav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Failed registering cluster: %s", err)
+	}
+
+	got := result.Spec.Names
+	expected := "natsclusters"
+	if got.Plural != expected {
+		t.Errorf("got: %s, expected: %s", got.Plural, expected)
+	}
+	expected = "natscluster"
+	if got.Singular != expected {
+		t.Errorf("got: %s, expected: %s", got.Plural, expected)
+	}
+	if len(got.ShortNames) < 1 {
+		t.Errorf("expected shortnames for the CRD: %+v", got.ShortNames)
+	}
+	expected = "nats"
+	if got.ShortNames[0] != expected {
+		t.Errorf("got: %s, expected: %s", got.ShortNames[0], expected)
+	}
+}
+
+type clients struct {
+	kc      k8sclient.CoreV1Interface
+	kcrdc   k8scrdclient.Interface
+	restcli *k8srestapi.RESTClient
+	config  *k8srestapi.Config
+}
+
+func newKubeClients() (*clients, error) {
+	var err error
+	var cfg *k8srestapi.Config
+	if kubeconfig := os.Getenv("KUBERNETES_CONFIG_PATH"); kubeconfig != "" {
+		cfg, err = k8sclientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+	kc, err := k8sclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	kcrdc, err := k8scrdclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	restcli, _, err := client.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	cl := &clients{
+		kc:      kc,
+		kcrdc:   kcrdc,
+		restcli: restcli,
+		config:  cfg,
+	}
+	return cl, nil
+}
+
+func newController() (*controller.Controller, error) {
+	cl, err := newKubeClients()
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE: Eventually use a namespace at random under a
+	// delete propagation policy for deleting the namespace.
+	config := controller.Config{
+		Namespace:  "default",
+		KubeCli:    cl.kc,
+		KubeExtCli: cl.kcrdc,
+	}
+	c := controller.New(config)
+
+	// FIXME: These are set on the package
+	controller.MasterHost = cl.config.Host
+	controller.KubeHttpCli = cl.restcli.Client
+	return c, nil
+}

--- a/test/operator/basic_test.go
+++ b/test/operator/basic_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pires/nats-operator/pkg/client"
-	"github.com/pires/nats-operator/pkg/controller"
+	"github.com/nats-io/nats-operator/pkg/client"
+	"github.com/nats-io/nats-operator/pkg/controller"
 	k8scrdclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -74,7 +74,7 @@ type clients struct {
 func newKubeClients() (*clients, error) {
 	var err error
 	var cfg *k8srestapi.Config
-	if kubeconfig := os.Getenv("KUBERNETES_CONFIG_PATH"); kubeconfig != "" {
+	if kubeconfig := os.Getenv("KUBERNETES_CONFIG_FILE"); kubeconfig != "" {
 		cfg, err = k8sclientcmd.BuildConfigFromFlags("", kubeconfig)
 	}
 	kc, err := k8sclient.NewForConfig(cfg)


### PR DESCRIPTION
Updates Travis to set up a minikube to which the operator can run tests against to verify changes in a branch without requiring the end-to-end tests that rely on an image to live off a registry.
It also updates the `controller` to use context so that its cancellation can be controlled during tests.