### PR TITLE
Use ConfigMap with the explicit routes for the cluster

### DIFF
--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -61,7 +61,7 @@ func (c *Cluster) reconcileSize(pods []*v1.Pod) error {
 		}
 		err = c.updateConfigMap()
 		if err != nil {
-			c.logger.Warningf("error update the shared config map: %s", err)
+			c.logger.Warningf("error updating the shared config map: %s", err)
 		}
 
 	} else if currentClusterSize > spec.Size {

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -26,7 +26,7 @@ import (
 // - if the cluster needs upgrade, it tries to upgrade existing peers, one by one.
 func (c *Cluster) reconcile(pods []*v1.Pod) error {
 	c.logger.Debugln("Start reconciling...")
-	defer c.logger.Infoln("Finish reconciling")
+	defer c.logger.Debugln("Finish reconciling")
 
 	spec := c.cluster.Spec
 
@@ -50,14 +50,20 @@ func (c *Cluster) reconcile(pods []*v1.Pod) error {
 func (c *Cluster) reconcileSize(pods []*v1.Pod) error {
 	spec := c.cluster.Spec
 
-	c.logger.Warningf("Cluster size needs reconciling: expected %d, has %d", spec.Size, len(pods))
+	c.logger.Infof("Cluster size needs reconciling: expected %d, has %d", spec.Size, len(pods))
 	// do we need to add or remove pods?
 	currentClusterSize := len(pods)
 	if currentClusterSize < spec.Size {
 		c.status.AppendScalingUpCondition(currentClusterSize, c.cluster.Spec.Size)
-		if err := c.createPod(); err != nil {
+		_, err := c.createPod()
+		if err != nil {
 			return err
 		}
+		err = c.updateConfigMap()
+		if err != nil {
+			c.logger.Warningf("error update the shared config map: %s", err)
+		}
+
 	} else if currentClusterSize > spec.Size {
 		c.status.AppendScalingDownCondition(currentClusterSize, c.cluster.Spec.Size)
 		if err := c.removePod(pods[currentClusterSize-1].Name); err != nil {

--- a/pkg/conf/natsconf.go
+++ b/pkg/conf/natsconf.go
@@ -1,0 +1,73 @@
+// natsconf is a package for producing NATS config programmatically.
+package natsconf
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+)
+
+type ServerConfig struct {
+	Host           string               `json:"host,omitempty"`
+	Port           int                  `json:"port,omitempty"`
+	HTTPPort       int                  `json:"http_port,omitempty"`
+	Cluster        *ClusterConfig       `json:"cluster,omitempty"`
+	TLS            *TLSConfig           `json:"tls,omitempty"`
+	Debug          bool                 `json:"debug,omitempty"`
+	Trace          bool                 `json:"trace,omitempty"`
+	WriteDeadline  string               `json:"write_deadline,omitempty"`
+	MaxConnections int                  `json:"max_connections,omitempty"`
+	MaxPayload     int                  `json:"max_payload,omitempty"`
+	Authorization  *AuthorizationConfig `json:"authorization,omitempty"`
+}
+
+type ClusterConfig struct {
+	Port          int                  `json:"port,omitempty"`
+	Routes        []string             `json:"routes,omitempty"`
+	TLS           *TLSConfig           `json:"tls,omitempty"`
+	Authorization *AuthorizationConfig `json:"authorization,omitempty"`
+}
+
+type TLSConfig struct {
+	CAFile           string   `json:"ca_file,omitempty"`
+	CertFile         string   `json:"cert_file,omitempty"`
+	KeyFile          string   `json:"key_file,omitempty"`
+	Verify           bool     `json:"verify,omitempty"`
+	CipherSuites     []string `json:"cipher_suites,omitempty"`
+	CurvePreferences []string `json:"curve_preferences,omitempty"`
+	Timeout          float64  `json:"timeout,omitempty"`
+}
+
+type AuthorizationConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Token    string `json:"token,omitempty"`
+	Timeout  int    `json:"timeout,omitempty"`
+}
+
+var (
+	ErrInvalidConfig = errors.New("natsconf: cannot produce valid config")
+)
+
+func Marshal(conf *ServerConfig) ([]byte, error) {
+	js, err := json.MarshalIndent(conf, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if len(js) < 1 || len(js)-1 <= 1 {
+		return nil, ErrInvalidConfig
+	}
+
+	// Slice the initial and final brackets from the
+	// resulting JSON configuration so gnatsd config parsers
+	// almost treats it as valid config.
+	js = js[1:]
+	js = js[:len(js)-1]
+
+	// Replacing all commas with line breaks still keeps
+	// arrays valid and makes the top level configuration
+	// be able to be parsed as gnatsd config.
+	result := bytes.Replace(js, []byte(","), []byte("\n"), -1)
+
+	return result, nil
+}

--- a/pkg/conf/natsconf_test.go
+++ b/pkg/conf/natsconf_test.go
@@ -1,0 +1,183 @@
+package natsconf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfMarshal(t *testing.T) {
+	tests := []struct {
+		input  *ServerConfig
+		output string
+		err    error
+	}{
+		{
+			input:  &ServerConfig{},
+			output: "",
+			err:    ErrInvalidConfig,
+		},
+		{
+			input: &ServerConfig{
+				HTTPPort: 8222,
+			},
+			output: `"http_port": 8222`,
+			err:    nil,
+		},
+		{
+			input: &ServerConfig{
+				Port: 4222,
+			},
+			output: `"port": 4222`,
+			err:    nil,
+		},
+		{
+			input: &ServerConfig{
+				Port:     4222,
+				HTTPPort: 8222,
+			},
+			output: `"port": 4222
+
+  "http_port": 8222`,
+			err: nil,
+		},
+		{
+			input: &ServerConfig{
+				Port:     4222,
+				HTTPPort: 8222,
+				Cluster: &ClusterConfig{
+					Port: 6222,
+				},
+			},
+			output: `"port": 4222
+
+  "http_port": 8222
+
+  "cluster": {
+    "port": 6222
+  }`,
+			err: nil,
+		},
+		{
+			input: &ServerConfig{
+				Port:     4222,
+				HTTPPort: 8222,
+				Cluster: &ClusterConfig{
+					Port: 6222,
+					Routes: []string{
+						"nats://nats-1.default.svc:6222",
+						"nats://nats-2.default.svc:6222",
+						"nats://nats-3.default.svc:6222",
+					},
+				},
+			},
+			output: `"port": 4222
+
+  "http_port": 8222
+
+  "cluster": {
+    "port": 6222
+
+    "routes": [
+      "nats://nats-1.default.svc:6222"
+
+      "nats://nats-2.default.svc:6222"
+
+      "nats://nats-3.default.svc:6222"
+    ]
+  }`,
+			err: nil,
+		},
+		{
+			input: &ServerConfig{
+				Port:     4222,
+				HTTPPort: 8222,
+				Debug:    true,
+				Trace:    true,
+				Cluster: &ClusterConfig{
+					Port: 6222,
+					Routes: []string{
+						"nats://nats-1.default.svc:6222",
+						"nats://nats-2.default.svc:6222",
+						"nats://nats-3.default.svc:6222",
+					},
+				},
+			},
+			output: `"port": 4222
+
+  "http_port": 8222
+
+  "cluster": {
+    "port": 6222
+
+    "routes": [
+      "nats://nats-1.default.svc:6222"
+
+      "nats://nats-2.default.svc:6222"
+
+      "nats://nats-3.default.svc:6222"
+    ]
+  }
+
+  "debug": true
+
+  "trace": true`,
+			err: nil,
+		},
+		{
+			input: &ServerConfig{
+				Port:     4222,
+				HTTPPort: 8222,
+				Cluster: &ClusterConfig{
+					Port: 6222,
+					Routes: []string{
+						"nats://nats-1.default.svc:6222",
+						"nats://nats-2.default.svc:6222",
+						"nats://nats-3.default.svc:6222",
+					},
+					TLS: &TLSConfig{
+						CAFile:   "/etc/nats-tls/ca.pem",
+						CertFile: "/etc/nats-tls/server.pem",
+						KeyFile:  "/etc/nats-tls/server-key.pem",
+					},
+				},
+			},
+			output: `"port": 4222
+
+  "http_port": 8222
+
+  "cluster": {
+    "port": 6222
+
+    "routes": [
+      "nats://nats-1.default.svc:6222"
+
+      "nats://nats-2.default.svc:6222"
+
+      "nats://nats-3.default.svc:6222"
+    ]
+
+    "tls": {
+      "ca_file": "/etc/nats-tls/ca.pem"
+
+      "cert_file": "/etc/nats-tls/server.pem"
+
+      "key_file": "/etc/nats-tls/server-key.pem"
+    }
+  }`,
+			err: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("config", func(t *testing.T) {
+			res, err := Marshal(tt.input)
+			if err != nil && tt.err == nil {
+				t.Errorf("Error: %s", err)
+			}
+			o := strings.TrimSpace(string(res))
+			if o != tt.output {
+				t.Errorf("Unexpected output: %v", o)
+			}
+		})
+	}
+}

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -116,7 +116,8 @@ func CreateMgmtService(kubecli corev1client.CoreV1Interface, clusterName, cluste
 			Name:       "monitoring",
 			Port:       constants.MonitoringPort,
 			TargetPort: intstr.FromInt(constants.MonitoringPort),
-			Protocol:   v1.ProtocolTCP},
+			Protocol:   v1.ProtocolTCP,
+		},
 	}
 	selectors := LabelsForCluster(clusterName)
 	selectors[LabelClusterVersionKey] = clusterVersion


### PR DESCRIPTION
Besides the pair of services the created NatsCluster also has a config map that is used to include the full list of the non-failed pods so far, this as one step in order to be able to use wildcard certificates for the cluster routes.

```sh
$ kubectl get cm test-nats-cluster-1 -o yaml
apiVersion: v1
kind: ConfigMap
data:
  nats.conf: |2

      "port": 4222

      "http_port": 8222

      "cluster": {
        "port": 6222

        "routes": [
          "nats://nats-4dnrj8qh1j.nats-cluster-1-mgmt.default.svc:6222"

          "nats://nats-cvms254b0l.nats-cluster-1-mgmt.default.svc:6222"

          "nats://nats-w142n49wt6.nats-cluster-1-mgmt.default.svc:6222"
        ]
      }
```