### PR TITLE
Add example and instructions for RBAC policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ before_script:
 script:
 - kubectl cluster-info 
 - cd $GOPATH/src/github.com/nats-io/nats-operator/test/operator/ && go test ./... -v
+- cd $GOPATH/src/github.com/nats-io/nats-operator/test/rbac && ./rbac-test.sh

--- a/README.md
+++ b/README.md
@@ -56,6 +56,44 @@ NAME                   AGE
 example-nats-cluster   1s
 ```
 
+### RBAC support
+
+If you have RBAC enabled (for example in GKE), you can run:
+
+```
+$ kubectl apply -f https://raw.githubusercontent.com/nats-io/nats-operator/master/example/deployment-rbac.yaml
+```
+
+Then this will deploy a `nats-operator` on the `nats-io` namespace.
+
+```
+$ kubectl -n nats-io logs deployment/nats-operator
+time="2018-03-23T00:45:49Z" level=info msg="nats-operator Version: 0.2.0-v1alpha2+git"
+time="2018-03-23T00:45:49Z" level=info msg="Git SHA: 4040d87"
+time="2018-03-23T00:45:49Z" level=info msg="Go Version: go1.9"
+time="2018-03-23T00:45:49Z" level=info msg="Go OS/Arch: linux/amd64"
+```
+
+Note that the NATS operator only monitors the `NatsCluster` resources
+which are created in the namespace where it was deployed, so if you
+want to create a cluster you have to specify the same one as the
+operator:
+
+```
+$ kubectl -n nats-io apply -f example/example-nats-cluster.yaml
+natscluster "example-nats-1" created
+
+$ kubectl -n nats-io get natsclusters
+NAME             AGE
+example-nats-1   6m
+
+$ kubectl -n nats-io get pods -l nats_cluster=example-nats-1
+NAME              READY     STATUS    RESTARTS   AGE
+nats-2jgb0tg3sm   1/1       Running   0          7m
+nats-h8z9dckvfr   1/1       Running   0          7m
+nats-px28gkx5wk   1/1       Running   0          6m
+```
+
 ### TLS support
 
 By using a pair of opaque secrets (one for the clients and then another for the routes),

--- a/example/deployment-rbac.yaml
+++ b/example/deployment-rbac.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nats-io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-operator
+  namespace: nats-io
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: nats-operator
+  namespace: nats-io
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: nats-operator
+  template:
+    metadata:
+      labels:
+        name: nats-operator
+    spec:
+      serviceAccountName: nats-operator
+      containers:
+      - name: nats-operator
+        image: connecteverything/nats-operator:0.2.0-v1alpha2
+        imagePullPolicy: Always
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nats-io:nats-operator-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nats-io:nats-operator
+subjects:
+- kind: ServiceAccount
+  name: nats-operator
+  namespace: nats-io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nats-io:nats-operator
+rules:
+# Allow creating CRDs
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ["*"]
+# Allow all actions on NatsClusters
+- apiGroups:
+  - nats.io
+  resources:
+  - natsclusters
+  verbs: ["*"]
+# Allow actions on basic Kubernetes objects
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - pods
+  - services
+  - endpoints
+  - events
+  verbs: ["*"]

--- a/test/rbac/rbac-test.sh
+++ b/test/rbac/rbac-test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Stop minikube if it is running.
+minikube status | grep Running && {
+    minikube stop
+}
+
+# Start minikube with policy enabled
+sudo minikube start  --vm-driver=none --kubernetes-version=v1.9.0 --extra-config=apiserver.Authorization.Mode=RBAC
+minikube update-context
+
+# Wait once again for cluster to be ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+
+# Bootstrap own user policy
+kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --serviceaccount=kube-system:default
+
+# Confirm delete the CRD in case present right now
+kubectl get crd | grep natscluster && {
+    kubectl delete crd natsclusters.nats.io
+}
+
+# Deploy the manifest with RBAC enabled
+kubectl apply -f ../../example/deployment-rbac.yaml
+
+# Wait until the CRD is ready
+attempts=0
+until kubectl get crd natsclusters.nats.io -o yaml | grep InitialNamesAccepted; do
+    if [[ attempts -eq 60 ]]; then
+        echo "Gave up waiting for CRD to be ready..."
+        kubectl -n nats-io logs deployment/nats-operator
+        exit 1
+    fi
+    ((++attempts))
+
+    echo "Waiting for CRD... ($attempts attempts)"
+    sleep 1
+done
+
+# Deploy an example manifest and wait for pods to appear
+kubectl -n nats-io apply -f ../../example/example-nats-cluster.yaml
+
+# Wait until 3 pods appear
+attempts=0
+until kubectl -n nats-io get pods | grep -v operator | grep nats | grep Running | wc -l | grep 3; do
+    if [[ attempts -eq 60 ]]; then
+        echo "Gave up waiting for NatsCluster to be ready..."
+        kubectl -n nats-io logs deployment/nats-operator
+        kubectl -n nats-io logs -l nats_cluster=example-nats-1
+        exit 1
+    fi
+
+    echo "Waiting for pods to appear ($attempts attempts)..."
+    ((++attempts))
+    sleep 1
+done
+
+# Show output to confirm.
+kubectl -n nats-io logs -l nats_cluster=example-nats-1


### PR DESCRIPTION
Add instructions to the README on how to configure policy for the `nats-operator` under a `nats-io` namespace:

Fixes #17 
Fixes #36 
