### PR TITLE
Update config map from NATS cluster if present on create

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ install:
 
 before_script:
 - go version
-- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-- sudo minikube start --vm-driver=none --kubernetes-version=v1.9.0
+- sudo minikube start --vm-driver=none --kubernetes-version=v1.10.0 --bootstrapper=localkube
 - minikube update-context
 - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -100,6 +100,10 @@ func init() {
 }
 
 func main() {
+	formatter := &logrus.TextFormatter{
+		FullTimestamp: true,
+	}
+	logrus.SetFormatter(formatter)
 	namespace = os.Getenv("MY_POD_NAMESPACE")
 	if len(namespace) == 0 {
 		logrus.Fatalf("must set env MY_POD_NAMESPACE")

--- a/pkg/garbagecollection/gc.go
+++ b/pkg/garbagecollection/gc.go
@@ -116,22 +116,22 @@ func (gc *GC) collectPods(option metav1.ListOptions, runningSet map[types.UID]bo
 }
 
 func (gc *GC) collectConfigMaps(option metav1.ListOptions, runningSet map[types.UID]bool) error {
-	srvs, err := gc.kubecli.ConfigMaps(gc.ns).List(option)
+	cms, err := gc.kubecli.ConfigMaps(gc.ns).List(option)
 	if err != nil {
 		return err
 	}
 
-	for _, srv := range srvs.Items {
-		if len(srv.OwnerReferences) == 0 {
-			gc.logger.Warningf("failed to check service %s: no owner", srv.GetName())
+	for _, cm := range cms.Items {
+		if len(cm.OwnerReferences) == 0 {
+			gc.logger.Warningf("failed to check service %s: no owner", cm.GetName())
 			continue
 		}
-		if !runningSet[srv.OwnerReferences[0].UID] {
-			err = gc.kubecli.ConfigMaps(gc.ns).Delete(srv.GetName(), nil)
+		if !runningSet[cm.OwnerReferences[0].UID] {
+			err = gc.kubecli.ConfigMaps(gc.ns).Delete(cm.GetName(), nil)
 			if err != nil && !kubernetesutil.IsKubernetesResourceNotFoundError(err) {
 				return err
 			}
-			gc.logger.Infof("deleted configmap (%v)", srv.GetName())
+			gc.logger.Infof("deleted configmap (%v)", cm.GetName())
 		}
 	}
 

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -229,9 +229,14 @@ func CreateConfigMap(kubecli corev1client.CoreV1Interface, clusterName, ns strin
 		return err
 	}
 
+	labels := map[string]string{
+		LabelAppKey:         LabelAppValue,
+		LabelClusterNameKey: clusterName,
+	}
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterName,
+			Name:   clusterName,
+			Labels: labels,
 		},
 		Data: map[string]string{
 			constants.ConfigFileName: string(rawConfig),
@@ -284,9 +289,14 @@ func UpdateConfigMap(kubecli corev1client.CoreV1Interface, clusterName, ns strin
 		return err
 	}
 
+	labels := map[string]string{
+		LabelAppKey:         LabelAppValue,
+		LabelClusterNameKey: clusterName,
+	}
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterName,
+			Labels: labels,
 		},
 		Data: map[string]string{
 			constants.ConfigFileName: string(rawConfig),

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -245,6 +245,13 @@ func CreateConfigMap(kubecli corev1client.CoreV1Interface, clusterName, ns strin
 	addOwnerRefToObject(cm.GetObjectMeta(), owner)
 
 	_, err = kubecli.ConfigMaps(ns).Create(cm)
+	if apierrors.IsAlreadyExists(err) {
+		// Skip in case it was created already and update instead
+		// with the latest configuration.
+		_, err = kubecli.ConfigMaps(ns).Update(cm)
+		return err
+	}
+
 	return err
 }
 
@@ -295,7 +302,7 @@ func UpdateConfigMap(kubecli corev1client.CoreV1Interface, clusterName, ns strin
 	}
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterName,
+			Name:   clusterName,
 			Labels: labels,
 		},
 		Data: map[string]string{

--- a/test/rbac/rbac-test.sh
+++ b/test/rbac/rbac-test.sh
@@ -10,7 +10,7 @@ minikube status | grep Running && {
 }
 
 # Start minikube with policy enabled
-sudo minikube start  --vm-driver=none --kubernetes-version=v1.9.0 --extra-config=apiserver.Authorization.Mode=RBAC
+sudo minikube start  --vm-driver=none --kubernetes-version=v1.10.0 --bootstrapper=localkube --extra-config=apiserver.Authorization.Mode=RBAC
 minikube update-context
 
 # Wait once again for cluster to be ready


### PR DESCRIPTION
On certain conditions the config map could be still around when the same name is used for the cluster.  In case this occurs, then reuse the object and update it with the latest configuration.

Fixes #41 