### PR TITLE
Use Secret instead of ConfigMap

### DIFF
--- a/cmd/reloader/main.go
+++ b/cmd/reloader/main.go
@@ -64,7 +64,7 @@ func main() {
 			log.Printf("Trapped \"%v\" signal\n", sig)
 			switch sig {
 			case syscall.SIGINT:
-				log.Println("Exiting...\n")
+				log.Println("Exiting...")
 				os.Exit(0)
 				return
 			case syscall.SIGTERM:

--- a/pkg/garbagecollection/gc.go
+++ b/pkg/garbagecollection/gc.go
@@ -116,7 +116,7 @@ func (gc *GC) collectPods(option metav1.ListOptions, runningSet map[types.UID]bo
 }
 
 func (gc *GC) collectConfigMaps(option metav1.ListOptions, runningSet map[types.UID]bool) error {
-	cms, err := gc.kubecli.ConfigMaps(gc.ns).List(option)
+	cms, err := gc.kubecli.Secrets(gc.ns).List(option)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (gc *GC) collectConfigMaps(option metav1.ListOptions, runningSet map[types.
 			continue
 		}
 		if !runningSet[cm.OwnerReferences[0].UID] {
-			err = gc.kubecli.ConfigMaps(gc.ns).Delete(cm.GetName(), nil)
+			err = gc.kubecli.Secrets(gc.ns).Delete(cm.GetName(), nil)
 			if err != nil && !kubernetesutil.IsKubernetesResourceNotFoundError(err) {
 				return err
 			}

--- a/test/operator/basic_test.go
+++ b/test/operator/basic_test.go
@@ -69,7 +69,7 @@ func TestRegisterCRD(t *testing.T) {
 	}
 }
 
-func TestCreateConfigMap(t *testing.T) {
+func TestCreateConfigSecret(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	runController(ctx, t)
@@ -123,7 +123,7 @@ func TestCreateConfigMap(t *testing.T) {
 		t.Errorf("Error waiting for pods to be created: %s", err)
 	}
 
-	cm, err := cl.kc.ConfigMaps(namespace).Get(name, k8smetav1.GetOptions{})
+	cm, err := cl.kc.Secrets(namespace).Get(name, k8smetav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Config map error: %v", err)
 	}
@@ -132,13 +132,13 @@ func TestCreateConfigMap(t *testing.T) {
 		t.Error("Config map was missing")
 	}
 	for _, pod := range podList.Items {
-		if !strings.Contains(conf, pod.Name) {
+		if !strings.Contains(string(conf), pod.Name) {
 			t.Errorf("Could not find pod %q in config", pod.Name)
 		}
 	}
 }
 
-func TestReplacePresentConfigMap(t *testing.T) {
+func TestReplacePresentConfigSecret(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	runController(ctx, t)
@@ -152,17 +152,17 @@ func TestReplacePresentConfigMap(t *testing.T) {
 	name := "test-nats-cluster-2"
 	namespace := "default"
 
-	// Create a configmap with the same name, that will
+	// Create a secret with the same name, that will
 	// be replaced with a new one by the operator.
-	cm := &k8sv1.ConfigMap{
+	cm := &k8sv1.Secret{
 		ObjectMeta: k8smetav1.ObjectMeta{
 			Name: name,
 		},
-		Data: map[string]string{
-			"nats.conf": "port: 4222",
+		Data: map[string][]byte{
+			"nats.conf": []byte("port: 4222"),
 		},
 	}
-	_, err = cl.kc.ConfigMaps(namespace).Create(cm)
+	_, err = cl.kc.Secrets(namespace).Create(cm)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func TestReplacePresentConfigMap(t *testing.T) {
 		t.Errorf("Error waiting for pods to be created: %s", err)
 	}
 
-	cm, err = cl.kc.ConfigMaps(namespace).Get(name, k8smetav1.GetOptions{})
+	cm, err = cl.kc.Secrets(namespace).Get(name, k8smetav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Config map error: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestReplacePresentConfigMap(t *testing.T) {
 		t.Error("Config map was missing")
 	}
 	for _, pod := range podList.Items {
-		if !strings.Contains(conf, pod.Name) {
+		if !strings.Contains(string(conf), pod.Name) {
 			t.Errorf("Could not find pod %q in config", pod.Name)
 		}
 	}

--- a/test/operator/config_reload_test.go
+++ b/test/operator/config_reload_test.go
@@ -125,7 +125,7 @@ func TestConfigMapReload_Servers(t *testing.T) {
 	time.Sleep(1 * time.Minute)
 }
 
-func TestConfigMapReload_Auth(t *testing.T) {
+func TestConfigSecretReload_Auth(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 	runController(ctx, t)
@@ -155,9 +155,10 @@ func TestConfigMapReload_Auth(t *testing.T) {
   }
 }
 `
+	authSecretName := fmt.Sprintf("%s-clients-auth", name)
 	cm := &k8sv1.Secret{
 		ObjectMeta: k8smetav1.ObjectMeta{
-			Name: name,
+			Name: authSecretName,
 		},
 		Data: map[string][]byte{
 			"anything": []byte(sec),
@@ -187,7 +188,7 @@ func TestConfigMapReload_Auth(t *testing.T) {
 				EnableConfigReload: true,
 			},
 			Auth: &spec.AuthConfig{
-				ClientsAuthSecret:  name,
+				ClientsAuthSecret:  authSecretName,
 				ClientsAuthTimeout: 10,
 			},
 		},
@@ -296,7 +297,7 @@ func TestConfigMapReload_Auth(t *testing.T) {
   }
 }
 `
-	result, err := cl.kc.Secrets(namespace).Get(name, k8smetav1.GetOptions{})
+	result, err := cl.kc.Secrets(namespace).Get(authSecretName, k8smetav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/operator/tls_test.go
+++ b/test/operator/tls_test.go
@@ -102,7 +102,7 @@ func TestCreateTLSSetup(t *testing.T) {
 	// Give some time for cluster to form
 	time.Sleep(2 * time.Second)
 
-	cm, err := cl.kc.ConfigMaps(namespace).Get(name, k8smetav1.GetOptions{})
+	cm, err := cl.kc.Secrets(namespace).Get(name, k8smetav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Config map error: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestCreateTLSSetup(t *testing.T) {
 		t.Error("Config map was missing")
 	}
 	for _, pod := range podList.Items {
-		if !strings.Contains(conf, pod.Name) {
+		if !strings.Contains(string(conf), pod.Name) {
 			t.Errorf("Could not find pod %q in config", pod.Name)
 		}
 


### PR DESCRIPTION
Now that the configuration file for from the cluster includes the credentials for authorization, changing it to be a handled as a secret instead.