### PR TITLE
Check CRD existence before attempting to create

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -228,16 +228,11 @@ func (c *Controller) makeClusterConfig() cluster.Config {
 func (c *Controller) initResource() (string, error) {
 	watchVersion := "0"
 	err := c.initCRD()
+	if err == kubernetesutil.ErrCRDAlreadyExists {
+		return c.findAllClusters()
+	}
 	if err != nil {
-		if kubernetesutil.IsKubernetesResourceAlreadyExistError(err) {
-			// CRD has been initialized before. We need to recover existing cluster.
-			watchVersion, err = c.findAllClusters()
-			if err != nil {
-				return "", err
-			}
-		} else {
-			return "", fmt.Errorf("fail to create CRD: %v", err)
-		}
+		return "", fmt.Errorf("fail to create CRD: %v", err)
 	}
 
 	return watchVersion, nil


### PR DESCRIPTION
Even though [the Operator pattern](https://coreos.com/blog/introducing-operators.html) recommends that operators should be responsible for creating custom resources, in a multi-tenant environment this would cause a security breach. 

In this PR, I've made an addition where NATS Operator checks for the existence of `natsclusters.nats.io` CRD and skips CreateCRD step in case it exists. 

