### PR TITLE
Add readiness probe to operator deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,13 @@ spec:
 To build the `nats-operator` Docker image:
 
 ```sh
-$ docker build -t <image>:<tag> .
+$ docker build -f docker/operator/Dockerfile . <image:tag>
+```
+
+To build the `nats-server-config-reloader`:
+
+```sh
+$ docker build -f docker/reloader/Dockerfile . <image:tag>
 ```
 
 You'll need Docker `17.06.0-ce` or higher.

--- a/example/deployment-rbac.yaml
+++ b/example/deployment-rbac.yaml
@@ -39,6 +39,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 3
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/example/deployment-rbac.yaml
+++ b/example/deployment-rbac.yaml
@@ -30,6 +30,9 @@ spec:
       - name: nats-operator
         image: connecteverything/nats-operator:0.2.3-v1alpha2
         imagePullPolicy: Always
+        ports:
+        - name: readyz
+          containerPort: 8080
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:
@@ -42,7 +45,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8080
+            port: readyz
           initialDelaySeconds: 15
           timeoutSeconds: 3
 ---

--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -25,3 +25,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 3

--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       - name: nats-operator
         image: connecteverything/nats-operator:0.2.3-v1alpha2
         imagePullPolicy: Always
+        ports:
+        - name: readyz
+          containerPort: 8080
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:
@@ -28,6 +31,6 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8080
+            port: readyz
           initialDelaySeconds: 15
           timeoutSeconds: 3


### PR DESCRIPTION
The operator process starts with an HTTP server that can serve as a readiness probe, so including as part of the deployment yaml examples:
https://github.com/nats-io/nats-operator/blob/b3aa986906b1396d1d7c37b883631042f898e5e6/cmd/operator/main.go#L148

Signed-off-by: Waldemar Quevedo <wally@synadia.com>