### PR TITLE
Fixed building on ARMv7

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 .glide/
 .idea/
 _output/
+docker
+docs
+example

--- a/docker/operator/Dockerfile
+++ b/docker/operator/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.9.0-alpine3.6 AS builder
+FROM golang:1.10-alpine3.8 AS builder
 WORKDIR $GOPATH/src/github.com/nats-io/nats-operator/
-COPY . .
 RUN apk add --update git
 RUN go get -u github.com/golang/dep/cmd/dep
+COPY . .
 RUN dep ensure -v -vendor-only
 RUN CGO_ENABLED=0 go build -ldflags "-X github.com/nats-io/nats-operator/version.GitSHA=`git rev-parse --short HEAD`" -installsuffix cgo -o /nats-operator ./cmd/operator/main.go
 
-FROM alpine:3.6
+FROM alpine:3.8
 COPY --from=builder /nats-operator /usr/local/bin/nats-operator
 CMD ["nats-operator"]

--- a/docker/reloader/Dockerfile
+++ b/docker/reloader/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.10.2-alpine AS builder
+FROM golang:1.10-alpine3.8 AS builder
 WORKDIR $GOPATH/src/github.com/nats-io/nats-operator/
-COPY . .
 RUN apk add --update git
 RUN go get -u github.com/golang/dep/cmd/dep
+COPY . .
 RUN dep ensure -v -vendor-only
 RUN CGO_ENABLED=0 go build -ldflags "-X github.com/nats-io/nats-operator/version.GitSHA=`git rev-parse --short HEAD`" -installsuffix cgo -o /nats-server-config-reloader ./cmd/reloader/main.go
 
-FROM alpine:3.6
+FROM alpine:3.8
 COPY --from=builder /nats-server-config-reloader /usr/local/bin/nats-server-config-reloader
 CMD ["nats-server-config-reloader"]

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -522,7 +522,7 @@ func (c *Cluster) reportFailedStatus() {
 
 	}
 
-	retryutil.Retry(retryInterval, math.MaxInt64, f)
+	retryutil.Retry(retryInterval, math.MaxInt32, f)
 }
 
 func (c *Cluster) name() string {


### PR DESCRIPTION
- Reordered Docker layers to speed-up build process
- Updated Go and Alpine versions (there's no `golang:1.9.0-alpine3.6` for arm32v7)
- Ignored files unnecessary for building