### PR TITLE
WIP: Added Docker multiarch build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,12 @@
 .glide/
 .idea/
 _output/
-docker
-docs
-example
+bin/
+docker/
+docs/
+example/
+test/
+*.md
+.gitignore
+Makefile
+.travis.yml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ vendor
 ## IntelliJ
 .idea
 *.iml
+
+docker/*/Dockerfile.*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+# TODO: arm64v8 is broken
+archs = amd64 arm32v6 # arm64v8
+operator = nats-operator
+reloader = nats-server-config-reloader
+tag = $(shell git describe --abbrev=0 --tags | sed 's/v//g')
+
+amd64_args = --arch amd64
+arm32v6_args = --arch arm --variant v6
+# TODO: arm64v8 is broken
+# arm64v8_args = --arch arm64 --variant v8
+
+_ensure_repo:
+	@test ! $(repo) &&\
+	echo repo must be set. >&2 &&\
+	exit 1 ||\
+	true
+
+.PHONY: operator
+operator: _ensure_repo
+	@- $(foreach a,$(archs), \
+		sed 's/FROM /FROM $a\//g' docker/operator/Dockerfile > docker/operator/Dockerfile.$a; \
+		docker build --tag $(repo)/$(operator):$a-$(tag) --file docker/operator/Dockerfile.$a .; \
+	)
+
+.PHONY: reloader
+reloader: _ensure_repo
+	@- $(foreach a,$(archs), \
+		sed 's/FROM /FROM $a\//g' docker/reloader/Dockerfile > docker/reloader/Dockerfile.$a; \
+		docker build --tag $(repo)/$(reloader):$a-$(tag) --file docker/reloader/Dockerfile.$a .; \
+	)
+
+.PHONY: push-operator
+push-operator: operator
+	@- $(foreach a,$(archs), \
+		docker push $(repo)/$(operator):$a-$(tag); \
+	)
+	docker manifest create $(repo)/$(operator):$(tag) $(foreach a,$(archs), $(repo)/$(operator):$a-$(tag)) || \
+		docker manifest create --amend $(repo)/$(operator):$(tag) $(foreach a,$(archs), $(repo)/$(operator):$a-$(tag))
+	@- $(foreach a,$(archs), \
+		docker manifest annotate \
+			$(repo)/$(operator):$(tag) \
+			$(repo)/$(operator):$a-$(tag) \
+			--os linux $($a_args); \
+	)
+	docker manifest push $(repo)/$(operator):$(tag)
+
+.PHONY: push-reloader
+push-reloader: reloader
+	@- $(foreach a,$(archs), \
+		docker push $(repo)/$(reloader):$a-$(tag); \
+	)
+	docker manifest create $(repo)/$(reloader):$(tag) $(foreach a,$(archs), $(repo)/$(reloader):$a-$(tag)) || \
+		docker manifest create --amend $(repo)/$(reloader):$(tag) $(foreach a,$(archs), $(repo)/$(reloader):$a-$(tag))
+	@- $(foreach a,$(archs), \
+		docker manifest annotate \
+			$(repo)/$(reloader):$(tag) \
+			$(repo)/$(reloader):$a-$(tag) \
+			--os linux $($a_args); \
+	)
+	docker manifest push $(repo)/$(reloader):$(tag)

--- a/docker/operator/Dockerfile
+++ b/docker/operator/Dockerfile
@@ -2,8 +2,9 @@ FROM golang:1.10-alpine3.8 AS builder
 WORKDIR $GOPATH/src/github.com/nats-io/nats-operator/
 RUN apk add --update git
 RUN go get -u github.com/golang/dep/cmd/dep
-COPY . .
+COPY Gopkg.lock Gopkg.toml ./
 RUN dep ensure -v -vendor-only
+COPY . .
 RUN CGO_ENABLED=0 go build -ldflags "-X github.com/nats-io/nats-operator/version.GitSHA=`git rev-parse --short HEAD`" -installsuffix cgo -o /nats-operator ./cmd/operator/main.go
 
 FROM alpine:3.8

--- a/docker/reloader/Dockerfile
+++ b/docker/reloader/Dockerfile
@@ -2,8 +2,9 @@ FROM golang:1.10-alpine3.8 AS builder
 WORKDIR $GOPATH/src/github.com/nats-io/nats-operator/
 RUN apk add --update git
 RUN go get -u github.com/golang/dep/cmd/dep
-COPY . .
+COPY Gopkg.lock Gopkg.toml ./
 RUN dep ensure -v -vendor-only
+COPY . .
 RUN CGO_ENABLED=0 go build -ldflags "-X github.com/nats-io/nats-operator/version.GitSHA=`git rev-parse --short HEAD`" -installsuffix cgo -o /nats-server-config-reloader ./cmd/reloader/main.go
 
 FROM alpine:3.8


### PR DESCRIPTION
This is a work in progress of a Docker multiarch build. `arm64v8` seems to be broken ATM. `qemu-user-static` needs to be setup for this to work.

### Usage

Build operator:

```sh
make operator repo=somedockerid
```

This will make `${somedockerid}/nats-operator/${arch}-${git_tag}` images.

Push operator and multiarch manifest:

```sh
make push-operator repo=somedockerid
```

Same commands are available for `reloader`.

Only `amd64` and `arm32v6` are tested and working when building from Fedora 28 x64 with Docker 18.06.0-ce and QEMU 2.11.2-2.fc28.

### TODO:

- [ ] Fix `arm64v8` build. Currently it's giving me:

```
go tool link: exit status 127
**
ERROR:/builddir/build/BUILD/qemu-2.11.2/qom/object.c:1645:object_get_canonical_path_component: code should not be reached
```