### PR TITLE
Update operator and manifests to use gnatsd v1.3.0 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ metadata:
   name: "example-nats-cluster"
 spec:
   size: 3
-  version: "1.2.0"
+  version: "1.3.0"
 ' | kubectl apply -f -
 ```
 
@@ -109,7 +109,7 @@ metadata:
 spec:
   # Number of nodes in the cluster
   size: 3
-  version: "1.2.0"
+  version: "1.3.0"
 
   tls:
     # Certificates to secure the NATS client connections:
@@ -168,7 +168,8 @@ metadata:
   name: example-nats
 spec:
   size: 3
-  version: "1.2.0"
+  version: "1.3.0"
+
   pod:
     enableConfigReload: true
   auth:

--- a/example/example-nats-cluster-auth.yaml
+++ b/example/example-nats-cluster-auth.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "example-nats-auth"
 spec:
   size: 3
-  version: "1.1.0"
+  version: "1.3.0"
 
   # On Kubernetes v1.10+ clusters with feature=`--feature-gates=PodShareProcessNamespace=true
   pod:

--- a/example/example-nats-cluster-tls.yaml
+++ b/example/example-nats-cluster-tls.yaml
@@ -6,9 +6,9 @@ spec:
   # Number of nodes in the cluster
   size: 3
 
-  # Must use 1.1.0 in order to allow waiting for the A record
+  # Must use at least 1.1.0 in order to allow waiting for the A record
   # from nodes in the cluster to be ready
-  version: "1.1.0"
+  version: "1.3.0"
 
   tls:
     # Certificates to secure the NATS client connections:

--- a/example/example-nats-cluster.yaml
+++ b/example/example-nats-cluster.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "example-nats-1"
 spec:
   size: 3
-  version: "1.1.0"
+  version: "1.3.0"

--- a/helm/nats-operator/templates/natscluster.yaml
+++ b/helm/nats-operator/templates/natscluster.yaml
@@ -4,8 +4,8 @@ metadata:
   name: "nats-cluster"
 spec:
   size: {{ .Values.clusterSize }}
-  version: "1.1.0"
-  
+  version: "1.3.0"
+
   pod:
     enableConfigReload: {{ .Values.configReload.enabled }}
     reloaderImage: {{ .Values.reloaderImage}}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -16,7 +16,7 @@ package constants
 
 const (
 	// DefaultNatsVersion is the nats server version to use.
-	DefaultNatsVersion = "1.1.0"
+	DefaultNatsVersion = "1.3.0"
 
 	// ClientPort is the port for the clients.
 	ClientPort = 4222


### PR DESCRIPTION
Signed-off-by: Waldemar Quevedo <wally@synadia.com>