### PR TITLE
Remove password from Secret metadata

### DIFF
--- a/helm/nats-operator/templates/secret.yaml
+++ b/helm/nats-operator/templates/secret.yaml
@@ -9,7 +9,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    test: "{{ .Values.auth.password }}"
 type: Opaque
 data:
   clients-auth.json: {{ (tpl (.Files.Get "config/client-auth.json") . ) | b64enc }}


### PR DESCRIPTION
This seems like a security issue to have the password in plaintext on the secret definition metadata.