### PR TITLE
Helm chart fix probes and resources

### DIFF
--- a/helm/nats-operator/README.md
+++ b/helm/nats-operator/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `podLabels`                          | Additional labels to be added to pods                                                        | `{}`                                            |
 | `updateStrategy`                     | Replicaset Update strategy                                                                   | `OnDelete`                                      |
 | `rollingUpdatePartition`             | Partition for Rolling Update strategy                                                        | `nil`                                           |
+| `resources`                          | CPU/Memory resource requests/limits                                                          | `{}`                                            |
 | `livenessProbe.enabled`              | Enable liveness probe                                                                        | `true`                                          |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                     | `30`                                            |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                                                               | `10`                                            |
@@ -83,7 +84,7 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `auth.password`                      | Client authentication password                                                               | `true`                                          |
 | `auth.users`                         | Allows multi-user authentication of 2 or more user                                           | `[]`                                            |
 | `auth.defaultPermissions`            | Enable default permissions for users                                                         | `{}`                                            |
-| `auth.defaultPermissions.publish`    | Default permission for publish requests                                                      | `nil`                                           |  
+| `auth.defaultPermissions.publish`    | Default permission for publish requests                                                      | `nil`                                           |
 | `auth.defaultPermissions.subscribe`  | Default permission for subscribe requests                                                    | `nil`                                           |
 | `tls.enabled`                        | Enable TLS                                                                                   | `false`                                         |
 | `tls.serverSecret`                   | Certificates to secure the NATS client connections (type: kubernetes.io/tls)                 | `nil`                                           |
@@ -98,7 +99,7 @@ The following table lists the configurable parameters of the NATS chart and thei
 
 Here is an example of how to setup a NATS cluster with client authentication.
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. 
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 ```bash
 $ helm install --name my-release --set auth.enabled=true,auth.username=my-user,auth.password=T0pS3cr3t .
@@ -116,8 +117,8 @@ You can consider editing the default values.yaml as it is easier to manage:
 auth:
   enabled: true
 
-  # username: 
-  # password: 
+  # username:
+  # password:
 
   # values.yaml
   users:

--- a/helm/nats-operator/templates/deployment.yaml
+++ b/helm/nats-operator/templates/deployment.yaml
@@ -46,9 +46,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-          ports:
-          - name: readyz
-            containerPort: 8080
+        ports:
+        - name: readyz
+          containerPort: 8080
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/helm/nats-operator/templates/deployment.yaml
+++ b/helm/nats-operator/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       containers:
       - name: nats-operator
-        image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}      
+        image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.pullPolicy  }}
         env:
         - name: MY_POD_NAMESPACE
@@ -47,30 +47,32 @@ spec:
             fieldRef:
               fieldPath: metadata.name
           ports:
-          - name: readyz 
+          - name: readyz
             containerPort: 8080
-          {{- if .Values.livenessProbe.enabled }}
-          livenessProbe:
-            httpGet:
-              path: /readyz
-              port: readyz
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-          {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: readyz
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-          {{- end }}
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /readyz
+            port: readyz
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: readyz
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10}}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}


### PR DESCRIPTION
This PR addresses two problems:
1. The `port`, `livenessProbe` and `readinessProbe` were defined a level too deep under `env` instead of `container`.
2. The `resources` requests and limits of the `values.yaml` file were not being applied to the container

Describing the running pod should now produce the following:
![image](https://user-images.githubusercontent.com/1437540/47381206-6ff88d80-d6cd-11e8-8af2-a42eda6643c0.png)

