### PR TITLE
Add prometheus-nats-exporter support

### DIFF
--- a/helm/nats-operator/README.md
+++ b/helm/nats-operator/README.md
@@ -97,7 +97,7 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `configReload.pullPolicy`            | Reload configuration image pull policy                                                       | `IfNotPresent`                                  |
 | `metrics.enabled`                    | Enable prometheus metrics exporter                                                           | `false`                                         |
 | `metrics.registry`                   | Prometheus metrics exporter image registry                                                   | `docker.io`                                     |
-| `metrics.repository`                 | Prometheus metrics exporter image name                                                       | `ttjiaa/prometheus-nats-exporter`               |
+| `metrics.repository`                 | Prometheus metrics exporter image name                                                       | `synadia/prometheus-nats-exporter`              |
 | `metrics.tag`                        | Prometheus metrics exporter image tag                                                        | `0.1.0`                                         |
 | `metrics.pullPolicy`                 | Prometheus metrics exporter image pull policy                                                | `IfNotPresent`                                  |
 

--- a/helm/nats-operator/README.md
+++ b/helm/nats-operator/README.md
@@ -96,9 +96,9 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `configReload.tag`                   | Reload configuration image tag                                                               | `0.2.2-v1alpha2`                                |
 | `configReload.pullPolicy`            | Reload configuration image pull policy                                                       | `IfNotPresent`                                  |
 | `metrics.enabled`                    | Enable prometheus metrics exporter                                                           | `false`                                         |
-| `metrics.registry`                   | Prometheus metrics exporter image registry                                                   |                                                 |
-| `metrics.repository`                 | Prometheus metrics exporter image name                                                       |                                                 |
-| `metrics.tag`                        | Prometheus metrics exporter image tag                                                        |                                                 |
+| `metrics.registry`                   | Prometheus metrics exporter image registry                                                   | `docker.io`                                     |
+| `metrics.repository`                 | Prometheus metrics exporter image name                                                       | `ttjiaa/prometheus-nats-exporter`               |
+| `metrics.tag`                        | Prometheus metrics exporter image tag                                                        | `0.1.0`                                         |
 | `metrics.pullPolicy`                 | Prometheus metrics exporter image pull policy                                                | `IfNotPresent`                                  |
 
 ### Example

--- a/helm/nats-operator/README.md
+++ b/helm/nats-operator/README.md
@@ -91,10 +91,15 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `tls.routesSecret`                   | Certificates to secure the routes. (type: kubernetes.io/tls)                                 | `nil`                                           |
 | `clusterSize`                        | Number of NATS nodes                                                                         | `3`                                             |
 | `configReload.enabled`               | Enable configuration reload                                                                  | `false`                                         |
-| `configReload.registry`              | Reload configuration name                                                                    | `docker.io`                                     |
+| `configReload.registry`              | Reload configuration image registry                                                          | `docker.io`                                     |
 | `configReload.repository`            | Reload configuration image name                                                              | `connecteverything/nats-server-config-reloader` |
 | `configReload.tag`                   | Reload configuration image tag                                                               | `0.2.2-v1alpha2`                                |
-| `configReload.pullPolicy`            | Reload configuration pull policy                                                             | `IfNotPresent`                                  |
+| `configReload.pullPolicy`            | Reload configuration image pull policy                                                       | `IfNotPresent`                                  |
+| `metrics.enabled`                    | Enable prometheus metrics exporter                                                           | `false`                                         |
+| `metrics.registry`                   | Prometheus metrics exporter image registry                                                   |                                                 |
+| `metrics.repository`                 | Prometheus metrics exporter image name                                                       |                                                 |
+| `metrics.tag`                        | Prometheus metrics exporter image tag                                                        |                                                 |
+| `metrics.pullPolicy`                 | Prometheus metrics exporter image pull policy                                                | `IfNotPresent`                                  |
 
 ### Example
 

--- a/helm/nats-operator/templates/natscluster.yaml
+++ b/helm/nats-operator/templates/natscluster.yaml
@@ -12,6 +12,11 @@ spec:
     reloaderImageTag: {{ .Values.configReload.tag }}
     reloaderImagePullPolicy: {{ .Values.configReload.pullPolicy }}
   
+    enableMetrics: {{ .Values.metrics.enabled }}
+    metricsImage: {{ .Values.metrics.repository }}
+    metricsImageTag: {{ .Values.metrics.tag }}
+    metricsImagePullPolicy: {{ .Values.metrics.pullPolicy }}
+
   auth:
     enableServiceAccounts: {{ .Values.auth.enableServiceAccounts }}
     clientsAuthSecret: {{ template "nats.fullname" . }}-clients-auth

--- a/helm/nats-operator/values.yaml
+++ b/helm/nats-operator/values.yaml
@@ -128,7 +128,7 @@ tls:
 
 clusterSize: 3
 
-## Configuration reload
+## Configuration Reload
 ##
 ## On Kubernetes v1.10+ clusters with feature=--feature-gates=PodShareProcessNamespace=true
 configReload:
@@ -136,4 +136,13 @@ configReload:
   registry: "docker.io"
   repository: "connecteverything/nats-server-config-reloader"
   tag: "0.2.2-v1alpha2"
+  pullPolicy: "IfNotPresent"
+
+## Prometheus Metrics Exporter
+##
+metrics:
+  enabled: false
+  registry: ""
+  repository: ""
+  tag: ""
   pullPolicy: "IfNotPresent"

--- a/helm/nats-operator/values.yaml
+++ b/helm/nats-operator/values.yaml
@@ -142,7 +142,7 @@ configReload:
 ##
 metrics:
   enabled: false
-  registry: ""
-  repository: ""
-  tag: ""
+  registry: "docker.io"
+  repository: "ttjiaa/prometheus-nats-exporter"
+  tag: "0.1.0"
   pullPolicy: "IfNotPresent"

--- a/helm/nats-operator/values.yaml
+++ b/helm/nats-operator/values.yaml
@@ -143,6 +143,6 @@ configReload:
 metrics:
   enabled: false
   registry: "docker.io"
-  repository: "ttjiaa/prometheus-nats-exporter"
+  repository: "synadia/prometheus-nats-exporter"
   tag: "0.1.0"
   pullPolicy: "IfNotPresent"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,6 +27,9 @@ const (
 	// MonitoringPort is the port for the server monitoring endpoint.
 	MonitoringPort = 8222
 
+	// MetricsPort is the port for the prometheus metrics endpoint.
+	MetricsPort = 7777
+
 	// ConfigMapVolumeName is the name of the volume use for the shared config map.
 	ConfigMapVolumeName = "nats-config"
 
@@ -78,4 +81,7 @@ const (
 	DefaultReloaderImage           = "connecteverything/nats-server-config-reloader"
 	DefaultReloaderImageTag        = "0.2.2-v1alpha2"
 	DefaultReloaderImagePullPolicy = "IfNotPresent"
+	DefaultMetricsImage            = ""
+	DefaultMetricsImageTag         = ""
+	DefaultMetricsImagePullPolicy  = "IfNotPresent"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,7 +81,7 @@ const (
 	DefaultReloaderImage           = "connecteverything/nats-server-config-reloader"
 	DefaultReloaderImageTag        = "0.2.2-v1alpha2"
 	DefaultReloaderImagePullPolicy = "IfNotPresent"
-	DefaultMetricsImage            = "ttjiaa/prometheus-nats-exporter"
+	DefaultMetricsImage            = "synadia/prometheus-nats-exporter"
 	DefaultMetricsImageTag         = "0.1.0"
 	DefaultMetricsImagePullPolicy  = "IfNotPresent"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,7 +81,7 @@ const (
 	DefaultReloaderImage           = "connecteverything/nats-server-config-reloader"
 	DefaultReloaderImageTag        = "0.2.2-v1alpha2"
 	DefaultReloaderImagePullPolicy = "IfNotPresent"
-	DefaultMetricsImage            = ""
-	DefaultMetricsImageTag         = ""
+	DefaultMetricsImage            = "ttjiaa/prometheus-nats-exporter"
+	DefaultMetricsImageTag         = "0.1.0"
 	DefaultMetricsImagePullPolicy  = "IfNotPresent"
 )

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -139,6 +139,19 @@ type PodPolicy struct {
 
 	// ReloaderImagePullPolicy is the pull policy for the reloader image.
 	ReloaderImagePullPolicy string `json:"reloaderImagePullPolicy,omitempty"`
+
+	// EnableMetrics attaches a sidecar to each NATS Server
+	// that will export prometheus metrics.
+	EnableMetrics bool `json:"enableMetrics,omitempty"`
+
+	// MetricsImage is the image to use for the prometheus metrics exporter.
+	MetricsImage string `json:"metricsImage,omitempty"`
+
+	// MetricsImageTag is the tag of the prometheus metrics exporter image.
+	MetricsImageTag string `json:"metricsImageTag,omitempty"`
+
+	// MetricsImagePullPolicy is the pull policy for the prometheus metrics exporter image.
+	MetricsImagePullPolicy string `json:"metricsImagePullPolicy,omitempty"`
 }
 
 // AuthConfig is the authorization configuration for

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -61,7 +61,7 @@ func natsPodContainer(clusterName, version string) v1.Container {
 	}
 }
 
-// reloaderContainer returns a NATS server pod container spec.
+// natsPodReloaderContainer returns a NATS server pod container spec for configuration reloader.
 func natsPodReloaderContainer(image, tag, pullPolicy string) v1.Container {
 	return v1.Container{
 		Name:            "reloader",
@@ -74,6 +74,29 @@ func natsPodReloaderContainer(image, tag, pullPolicy string) v1.Container {
 			"-pid",
 			constants.PidFilePath,
 		},
+	}
+}
+
+// natsPodMetricsContainer returns a NATS server pod container spec for prometheus metrics exporter.
+func natsPodMetricsContainer(image, tag, pullPolicy string) v1.Container {
+	return v1.Container{
+		Name:            "metrics",
+		Image:           fmt.Sprintf("%s:%s", image, tag),
+		ImagePullPolicy: v1.PullPolicy(pullPolicy),
+		Command:         []string{},
+		Ports: []v1.ContainerPort{
+			{
+				Name:          "metrics",
+				ContainerPort: int32(constants.MetricsPort),
+				Protocol:      v1.ProtocolTCP,
+			},
+		},
+		Args: []string{
+			"-connz",
+			"-routez",
+			"-subz",
+			"-varz",
+			fmt.Sprintf("http://localhost:%d", constants.MonitoringPort)},
 	}
 }
 


### PR DESCRIPTION
This PR:
- Adds support for attaching a `prometheus-nats-exporter` sidecar container in the nats cluster pods
- Adds corresponding support for enabling the use of `prometheus-nats-exporter` in helm chart

This PR potentially resolves: https://github.com/nats-io/nats-operator/issues/40

---

Currently, [`synadia/prometheus-nats-exporter:0.1.0`](https://hub.docker.com/r/synadia/prometheus-nats-exporter/) is used by default, based off of release [v0.1.0](https://github.com/nats-io/prometheus-nats-exporter/releases/tag/v0.1.0).

There is also an open issue for adding official `prometheus-nats-exporter` images into `docker-library`, as outlined in:
- https://github.com/nats-io/prometheus-nats-exporter/issues/48
- https://github.com/docker-library/official-images/pull/4069

Once the above is merged, it may become an additional option for the `prometheus-nats-exporter` image repo.

---

`nats-operator` pod and `nats-cluster` pods running:

![screen shot 2018-10-25 at 4 16 13 pm](https://user-images.githubusercontent.com/9013477/47527783-69a31680-d871-11e8-916c-cea2c5c54718.png)


`metrics` container in `nats-cluseter` pod:

![screen shot 2018-10-25 at 4 10 56 pm](https://user-images.githubusercontent.com/9013477/47527504-a91d3300-d870-11e8-9bd8-070dc438df40.png)


Port forwarding to expose `http://localhost:7777/metrics` endpoint:
```
kubectl port-forward nats-cluster-1 7777:7777
  Forwarding from 127.0.0.1:7777 -> 7777
```
![screen shot 2018-10-25 at 4 13 53 pm](https://user-images.githubusercontent.com/9013477/47527656-0a450680-d871-11e8-883f-6d2b91f7407a.png)

