### PR TITLE
Create CRD when creating operator in manifests

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,4 +1,34 @@
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: natsclusters.nats.io
+spec:
+  group: nats.io
+  names:
+    kind: NatsCluster
+    listKind: NatsClusterList
+    plural: natsclusters
+    singular: natscluster
+    shortNames:
+    - nats
+  scope: Namespaced
+  version: v1alpha2
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: natsserviceroles.nats.io
+spec:
+  group: nats.io
+  names:
+    kind: NatsServiceRole
+    listKind: NatsServiceRoleList
+    plural: natsserviceroles
+    singular: natsservicerole
+  scope: Namespaced
+  version: v1alpha2
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:


### PR DESCRIPTION
Partially resolves #81. Currently in case CRD not present, then the operator will create it (after doing a lookup first: #55).

Signed-off-by: Waldemar Quevedo <wally@synadia.com>