### PR TITLE
crds: revisit register and wait

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -50,7 +50,7 @@ type NatsCluster struct {
 }
 
 // GetGroupVersionKind returns a GroupVersionKind based on the current GroupVersion and the specified Kind.
-func (c* NatsCluster) GetGroupVersionKind() schema.GroupVersionKind {
+func (c *NatsCluster) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind(CRDResourceKind)
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -25,10 +25,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nats-io/nats-operator/pkg/debug"
-	"github.com/nats-io/nats-operator/pkg/garbagecollection"
 	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
 	natsalphav2client "github.com/nats-io/nats-operator/pkg/client/clientset/versioned/typed/nats/v1alpha2"
+	"github.com/nats-io/nats-operator/pkg/debug"
+	"github.com/nats-io/nats-operator/pkg/garbagecollection"
 	kubernetesutil "github.com/nats-io/nats-operator/pkg/util/kubernetes"
 	"github.com/nats-io/nats-operator/pkg/util/retryutil"
 	"github.com/sirupsen/logrus"
@@ -330,7 +330,7 @@ func checkClientAuthUpdate(c *Cluster, secretLastResourceVersion string, cRoles 
 		}
 
 		// Check in case there were deletions in the number of roles.
-		for uid, _ := range cRoles {
+		for uid := range cRoles {
 			if _, ok := aRoles[uid]; !ok {
 				shouldUpdate = true
 

--- a/pkg/util/context/context.go
+++ b/pkg/util/context/context.go
@@ -1,0 +1,27 @@
+// Copyright 2017 The nats-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"context"
+	"time"
+)
+
+// WithTimeout returns a new context with no parent context and with the specified timeout.
+func WithTimeout(t time.Duration) context.Context {
+	// Ignore the cancel function as most of the times we don't need it.
+	ctx, _ := context.WithTimeout(context.TODO(), t)
+	return ctx
+}

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -18,8 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/nats-io/nats-operator/pkg/constants"
 	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
+	"github.com/nats-io/nats-operator/pkg/constants"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/util/kubernetes/selectors.go
+++ b/pkg/util/kubernetes/selectors.go
@@ -1,0 +1,26 @@
+// Copyright 2017 The nats-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/fields"
+)
+
+// byCoordinates returns a field selector that can be used to filter Kubernetes resources based on their name and namespace.
+func byCoordinates(name, namespace string) fields.Selector {
+	return fields.ParseSelectorOrDie(fmt.Sprintf("metadata.name==%s,metadata.namespace==%s", name, namespace))
+}

--- a/test/operator/config_reload_test.go
+++ b/test/operator/config_reload_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
 	k8sv1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8swaitutil "k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
+	kubernetesutil "github.com/nats-io/nats-operator/pkg/util/kubernetes"
 )
 
 func TestConfigMapReload_Servers(t *testing.T) {
@@ -23,8 +25,12 @@ func TestConfigMapReload_Servers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Wait for the CRD to be registered in the background.
-	time.Sleep(10 * time.Second)
+
+	// Wait for the CRDs to become ready.
+	if err := kubernetesutil.WaitCRDs(cl.kcrdc); err != nil {
+		t.Fatal(err)
+	}
+
 	name := "test-nats-cluster-reload-1"
 	namespace := "default"
 
@@ -134,8 +140,12 @@ func TestConfigSecretReload_Auth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Wait for the CRD to be registered in the background.
-	time.Sleep(10 * time.Second)
+
+	// Wait for the CRDs to become ready.
+	if err := kubernetesutil.WaitCRDs(cl.kcrdc); err != nil {
+		t.Fatal(err)
+	}
+
 	name := "test-nats-cluster-reload-auth-1"
 	namespace := "default"
 
@@ -359,6 +369,11 @@ func TestConfigNatsServiceRolesReload_Auth(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Wait for the CRDs to become ready.
+	if err := kubernetesutil.WaitCRDs(cl.kcrdc); err != nil {
+		t.Fatal(err)
+	}
+
 	var (
 		userRoleName      = "nats-user-2"
 		adminUserRoleName = "nats-admin-user"
@@ -412,9 +427,6 @@ func TestConfigNatsServiceRolesReload_Auth(t *testing.T) {
 			Namespace: namespace,
 		},
 	}
-
-	// Wait for the CRD to be registered in the background.
-	time.Sleep(10 * time.Second)
 
 	_, err = cl.kc.ServiceAccounts(namespace).Create(userServiceAccount)
 	if err != nil {

--- a/test/operator/tls_test.go
+++ b/test/operator/tls_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
 	k8sv1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8swaitutil "k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
+	kubernetesutil "github.com/nats-io/nats-operator/pkg/util/kubernetes"
 )
 
 func TestCreateTLSSetup(t *testing.T) {
@@ -24,8 +26,11 @@ func TestCreateTLSSetup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Wait for the CRD to be registered in the background.
-	time.Sleep(10 * time.Second)
+
+	// Wait for the CRDs to become ready.
+	if err := kubernetesutil.WaitCRDs(cl.kcrdc); err != nil {
+		t.Fatal(err)
+	}
 
 	name := "nats"
 	namespace := "default"


### PR DESCRIPTION
This PR is the second of a series of rework changes that will be pushed to master branch altogether when the rework is done.

This PR improves the registration of the `NatsCluster` and the `NatsServiceRole` CRDs by introducing a "create or update" strategy. This allows the operator to update the CRDs without manual intervention, whenever required, and paves the way for the future introduction of CRD versioning and additional printer columns.

It also introduces a _wait_ step during CRDs registration, meaning the controller will only start processing resources once the `Established` condition has been appended to both CRDs.

Finally, this PR gets rid `time.Sleep(...)` calls in `test/operator` in favor of `WaitCRDs(...)`.