### PR TITLE
Added option to modify server image to custom image

### DIFF
--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -36,7 +36,7 @@ func (c *Cluster) upgradePod(oldPod *v1.Pod) error {
 	oldpod := pod.DeepCopy()
 
 	c.logger.Infof("upgrading the NATS member %v from %s to %s", pod.GetName(), kubernetesutil.GetNATSVersion(pod), c.cluster.Spec.Version)
-	pod.Spec.Containers[0].Image = kubernetesutil.MakeNATSImage(c.cluster.Spec.Version)
+	pod.Spec.Containers[0].Image = kubernetesutil.MakeNATSImage(c.cluster.Spec.Version, c.cluster.Spec.ServerImage)
 	pod.Labels[kubernetesutil.LabelClusterVersionKey] = c.cluster.Spec.Version
 	kubernetesutil.SetNATSVersion(pod, c.cluster.Spec.Version)
 

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -74,6 +74,8 @@ type ClusterSpec struct {
 	//
 	Version string `json:"version"`
 
+	ServerImage string `json:"serverImage"`
+
 	// Paused is to pause the control of the operator for the cluster.
 	Paused bool `json:"paused,omitempty"`
 
@@ -188,6 +190,9 @@ func (c *ClusterSpec) Validate() error {
 func (c *ClusterSpec) Cleanup() {
 	if len(c.Version) == 0 {
 		c.Version = constants.DefaultNatsVersion
+	}
+	if len(c.ServerImage) == 0 {
+		c.ServerImage = constants.DefaultServerImage
 	}
 
 	c.Version = strings.TrimLeft(c.Version, "v")

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -74,8 +74,8 @@ func GetPodNames(pods []*v1.Pod) []string {
 	return res
 }
 
-func MakeNATSImage(version string) string {
-	return fmt.Sprintf("nats:%v", version)
+func MakeNATSImage(version string, serverImage string) string {
+	return fmt.Sprintf("%s:%v", serverImage, version)
 }
 
 func PodWithNodeSelector(p *v1.Pod, ns map[string]string) *v1.Pod {
@@ -545,7 +545,7 @@ func NewNatsPodSpec(name, clusterName string, cs spec.ClusterSpec, owner metav1.
 	volumeMount = newNatsPidFileVolumeMount()
 	volumeMounts = append(volumeMounts, volumeMount)
 
-	container := natsPodContainer(clusterName, cs.Version)
+	container := natsPodContainer(clusterName, cs.Version, cs.ServerImage)
 	container = containerWithLivenessProbe(container, natsLivenessProbe())
 
 	// In case TLS was enabled as part of the NATS cluster

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -27,7 +27,7 @@ import (
 )
 
 // natsPodContainer returns a NATS server pod container spec.
-func natsPodContainer(clusterName, version string) v1.Container {
+func natsPodContainer(clusterName, version string, serverImage string) v1.Container {
 	return v1.Container{
 		Env: []v1.EnvVar{
 			{
@@ -40,7 +40,7 @@ func natsPodContainer(clusterName, version string) v1.Container {
 			},
 		},
 		Name:  "nats",
-		Image: MakeNATSImage(version),
+		Image: MakeNATSImage(version, serverImage),
 		Ports: []v1.ContainerPort{
 			{
 				Name:          "cluster",


### PR DESCRIPTION
Regarding Issue #90 
Added serverImage option to natsCluster CRD to support customImage

An example CRD with custom image. 
```
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "example-nats-1"
spec:
  size: 3
  version "1.3.0"
  serverImage: "customImage"
```

This will ultimately create a nats cluster using customImage:1.3.0 as the serverImage.  
DefaultServerImage in constants will be used(also set in CRD) if serverImage is not set.  
