### PR TITLE
controller: use the work queue

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v0.32.0"
 
 [[projects]]
+  digest = "1:7e77c179d2f1df5c29550c9822dccda4ce31745e70464f16cacc713a1f0413ef"
+  name = "github.com/Azure/draft"
+  packages = ["pkg/kube/podutil"]
+  pruneopts = ""
+  revision = "5433afea1421810ae9d828631d8651de913b347a"
+  version = "v0.16.0"
+
+[[projects]]
   branch = "master"
   digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
   name = "github.com/beorn7/perks"
@@ -487,6 +495,50 @@
   packages = [
     "discovery",
     "discovery/fake",
+    "informers",
+    "informers/admissionregistration",
+    "informers/admissionregistration/v1alpha1",
+    "informers/admissionregistration/v1beta1",
+    "informers/apps",
+    "informers/apps/v1",
+    "informers/apps/v1beta1",
+    "informers/apps/v1beta2",
+    "informers/autoscaling",
+    "informers/autoscaling/v1",
+    "informers/autoscaling/v2beta1",
+    "informers/autoscaling/v2beta2",
+    "informers/batch",
+    "informers/batch/v1",
+    "informers/batch/v1beta1",
+    "informers/batch/v2alpha1",
+    "informers/certificates",
+    "informers/certificates/v1beta1",
+    "informers/coordination",
+    "informers/coordination/v1beta1",
+    "informers/core",
+    "informers/core/v1",
+    "informers/events",
+    "informers/events/v1beta1",
+    "informers/extensions",
+    "informers/extensions/v1beta1",
+    "informers/internalinterfaces",
+    "informers/networking",
+    "informers/networking/v1",
+    "informers/policy",
+    "informers/policy/v1beta1",
+    "informers/rbac",
+    "informers/rbac/v1",
+    "informers/rbac/v1alpha1",
+    "informers/rbac/v1beta1",
+    "informers/scheduling",
+    "informers/scheduling/v1alpha1",
+    "informers/scheduling/v1beta1",
+    "informers/settings",
+    "informers/settings/v1alpha1",
+    "informers/storage",
+    "informers/storage/v1",
+    "informers/storage/v1alpha1",
+    "informers/storage/v1beta1",
     "kubernetes",
     "kubernetes/scheme",
     "kubernetes/typed/admissionregistration/v1alpha1",
@@ -520,6 +572,33 @@
     "kubernetes/typed/storage/v1",
     "kubernetes/typed/storage/v1alpha1",
     "kubernetes/typed/storage/v1beta1",
+    "listers/admissionregistration/v1alpha1",
+    "listers/admissionregistration/v1beta1",
+    "listers/apps/v1",
+    "listers/apps/v1beta1",
+    "listers/apps/v1beta2",
+    "listers/autoscaling/v1",
+    "listers/autoscaling/v2beta1",
+    "listers/autoscaling/v2beta2",
+    "listers/batch/v1",
+    "listers/batch/v1beta1",
+    "listers/batch/v2alpha1",
+    "listers/certificates/v1beta1",
+    "listers/coordination/v1beta1",
+    "listers/core/v1",
+    "listers/events/v1beta1",
+    "listers/extensions/v1beta1",
+    "listers/networking/v1",
+    "listers/policy/v1beta1",
+    "listers/rbac/v1",
+    "listers/rbac/v1alpha1",
+    "listers/rbac/v1beta1",
+    "listers/scheduling/v1alpha1",
+    "listers/scheduling/v1beta1",
+    "listers/settings/v1alpha1",
+    "listers/storage/v1",
+    "listers/storage/v1alpha1",
+    "listers/storage/v1beta1",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
     "pkg/apis/clientauthentication/v1beta1",
@@ -542,6 +621,7 @@
     "tools/pager",
     "tools/record",
     "tools/reference",
+    "tools/watch",
     "transport",
     "util/buffer",
     "util/cert",
@@ -565,10 +645,19 @@
   pruneopts = ""
   revision = "72693cb1fadd73ae2742f6fe29af77d1aecdd8cd"
 
+[[projects]]
+  digest = "1:6061aa42761235df375f20fa4a1aa6d1845cba3687575f3adb2ef3f3bc540af5"
+  name = "k8s.io/kubernetes"
+  packages = ["pkg/util/slice"]
+  pruneopts = ""
+  revision = "17c77c7898218073f14c8d573582e8d2313dc740"
+  version = "v1.12.2"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/Azure/draft/pkg/kube/podutil",
     "github.com/fsnotify/fsnotify",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
@@ -580,6 +669,7 @@
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/fields",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
@@ -594,10 +684,12 @@
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/informers",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/apps/v1beta1",
     "k8s.io/client-go/kubernetes/typed/core/v1",
+    "k8s.io/client-go/listers/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
@@ -606,8 +698,10 @@
     "k8s.io/client-go/tools/leaderelection",
     "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/record",
+    "k8s.io/client-go/tools/watch",
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/workqueue",
+    "k8s.io/kubernetes/pkg/util/slice",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -28,6 +28,13 @@ import (
 	"github.com/nats-io/nats-operator/pkg/constants"
 )
 
+const (
+	// clientAuthSecretResourceVersionAnnotationKey is the key of the annotation that holds the last-observed resource version of the secret containing authentication data for the NATS cluster.
+	clientAuthSecretResourceVersionAnnotationKey = "nats.io/cas"
+	// natsServiceRolesHashAnnotationKey is the key of the annotation that holds the hash of the comma-separated list of NatsServiceRole UIDs associated with the NATS cluster.
+	natsServiceRolesHashAnnotationKey = "nats.io/nsr"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type NatsClusterList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -276,6 +283,11 @@ func (cs *ClusterStatus) Control() {
 	cs.ControlPaused = false
 }
 
+// SetSize sets the current size of the cluster.
+func (cs *ClusterStatus) SetSize(size int) {
+	cs.Size = size
+}
+
 func (cs *ClusterStatus) SetCurrentVersion(v string) {
 	cs.CurrentVersion = v
 }
@@ -302,12 +314,10 @@ func (cs *ClusterStatus) AppendScalingDownCondition(from, to int) {
 	cs.appendCondition(c)
 }
 
-func (cs *ClusterStatus) AppendUpgradingCondition(to string, member string) {
-	reason := fmt.Sprintf("upgrading cluster member %s version to %v", member, to)
-
+func (cs *ClusterStatus) AppendUpgradingCondition(from, to string) {
 	c := ClusterCondition{
 		Type:           ClusterConditionUpgrading,
-		Reason:         reason,
+		Reason:         fmt.Sprintf("upgrading cluster version from %s to %s", from, to),
 		TransitionTime: time.Now().Format(time.RFC3339),
 	}
 	cs.appendCondition(c)
@@ -316,7 +326,7 @@ func (cs *ClusterStatus) AppendUpgradingCondition(to string, member string) {
 func (cs *ClusterStatus) SetReadyCondition() {
 	c := ClusterCondition{
 		Type:           ClusterConditionReady,
-		Reason:         "Current cluster state matches target state.",
+		Reason:         "current state matches desired state",
 		TransitionTime: time.Now().Format(time.RFC3339),
 	}
 
@@ -340,5 +350,45 @@ func (cs *ClusterStatus) appendCondition(c ClusterCondition) {
 }
 
 func scalingReason(from, to int) string {
-	return fmt.Sprintf("Current cluster size: %d, desired cluster size: %d", from, to)
+	return fmt.Sprintf("scaling cluster from %d to %d peers", from, to)
+}
+
+// GetClientAuthSecretResourceVersion returns the last-observed resource version of the secret containing authentication data for the NATS cluster.
+func (c *NatsCluster) GetClientAuthSecretResourceVersion() string {
+	if c.Annotations == nil {
+		return ""
+	}
+	res, ok := c.Annotations[clientAuthSecretResourceVersionAnnotationKey]
+	if !ok {
+		return ""
+	}
+	return res
+}
+
+// SetClientAuthSecretResourceVersion sets the last-observed resource version of the secret containing authentication data for the NATS cluster.
+func (c *NatsCluster) SetClientAuthSecretResourceVersion(v string) {
+	if c.Annotations == nil {
+		c.Annotations = make(map[string]string, 1)
+	}
+	c.Annotations[clientAuthSecretResourceVersionAnnotationKey] = v
+}
+
+// GetNatsServiceRolesHash returns the hash of the comma-separated list of NatsServiceRole UIDs associated with the NATS cluster.
+func (c *NatsCluster) GetNatsServiceRolesHash() string {
+	if c.Annotations == nil {
+		return ""
+	}
+	res, ok := c.Annotations[natsServiceRolesHashAnnotationKey]
+	if !ok {
+		return ""
+	}
+	return res
+}
+
+// SetNatsServiceRolesHash sets the hash of the comma-separated list of NatsServiceRole UIDs associated with the NATS cluster.
+func (c *NatsCluster) SetNatsServiceRolesHash(v string) {
+	if c.Annotations == nil {
+		c.Annotations = make(map[string]string, 1)
+	}
+	c.Annotations[natsServiceRolesHashAnnotationKey] = v
 }

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -15,87 +15,92 @@
 package cluster
 
 import (
-	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
 	kubernetesutil "github.com/nats-io/nats-operator/pkg/util/kubernetes"
-
-	"k8s.io/api/core/v1"
 )
 
-// reconcile reconciles cluster current state to desired state specified by spec.
-// - it tries to reconcile the cluster to desired size.
-// - if the cluster needs upgrade, it tries to upgrade existing peers, one by one.
-func (c *Cluster) reconcile(pods []*v1.Pod) error {
-	c.logger.Debugln("Start reconciling...")
-	defer c.logger.Debugln("Finish reconciling")
-
-	spec := c.cluster.Spec
-
-	clusterNeedsResize := len(pods) != spec.Size
-	clusterNeedsUpgrade := needsUpgrade(pods, spec)
-
-	if clusterNeedsResize {
-		return c.reconcileSize(pods)
+// checkPods reconciles the number and the version of pods belonging to the current NATS cluster.
+func (c *Cluster) checkPods() error {
+	if err := c.reconcileSize(); err != nil {
+		return err
 	}
-	if clusterNeedsUpgrade {
-		return c.reconcileUpgrade(pods, spec)
+	return c.reconcileVersion()
+}
+
+// reconcileSize reconciles the size of the NATS cluster.
+func (c *Cluster) reconcileSize() error {
+	// Grab an up-to-date list of pods that are currently running.
+	// Pending pods may be ignored safely as we have previously made sure no pods are in pending state.
+	pods, _, err := c.pollPods()
+	if err != nil {
+		return err
 	}
 
-	c.status.SetCurrentVersion(spec.Version)
-	c.status.SetReadyCondition()
+	// Grab the current and desired size of the NATS cluster.
+	currentSize := len(pods)
+	desiredSize := c.cluster.Spec.Size
 
+	if currentSize > desiredSize {
+		// Report that we are scaling the cluster down.
+		c.cluster.Status.AppendScalingDownCondition(currentSize, desiredSize)
+		// Remove extra pods as required in order to meet the desired size.
+		// As we remove each pod, we must update the config secret so that routes are re-computed.
+		for idx := currentSize - 1; idx >= desiredSize; idx-- {
+			if err := c.removePod(pods[idx]); err != nil {
+				return err
+			}
+			if err := c.updateConfigSecret(); err != nil {
+				return err
+			}
+		}
+	}
+
+	if currentSize < desiredSize {
+		// Report that we are scaling the cluster up.
+		c.cluster.Status.AppendScalingUpCondition(currentSize, desiredSize)
+		// Create pods as required in order to meet the desired size.
+		// As we create each pod, we must update the config secret so that routes are re-computed.
+		for idx := currentSize; idx < desiredSize; idx++ {
+			if _, err := c.createPod(); err != nil {
+				return err
+			}
+			if err := c.updateConfigSecret(); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Update the reported size before returning.
+	c.cluster.Status.SetSize(desiredSize)
 	return nil
 }
 
-// reconcileSize reconciles the size of cluster.
-func (c *Cluster) reconcileSize(pods []*v1.Pod) error {
-	spec := c.cluster.Spec
+// reconcileVersion reconciles the version of pods belonging to the NATS cluster.
+func (c *Cluster) reconcileVersion() error {
+	// Grab an up-to-date list of pods that are currently running.
+	// Pending pods may be ignored safely as we have previously made sure no pods are in pending state.
+	pods, _, err := c.pollPods()
+	if err != nil {
+		return err
+	}
 
-	c.logger.Infof("Cluster size needs reconciling: expected %d, has %d", spec.Size, len(pods))
+	// Grab the current and desired version of the NATS cluster.
+	currentVersion := c.cluster.Status.CurrentVersion
+	desiredVersion := c.cluster.Spec.Version
 
-	currentClusterSize := len(pods)
-	if currentClusterSize < spec.Size {
-		c.status.AppendScalingUpCondition(currentClusterSize, c.cluster.Spec.Size)
-		_, err := c.createPod()
-		if err != nil {
-			return err
-		}
-		if err = c.updateConfigMap(); err != nil {
-			c.logger.Warningf("error updating the shared config map: %s", err)
-		}
-
-	} else if currentClusterSize > spec.Size {
-		c.status.AppendScalingDownCondition(currentClusterSize, c.cluster.Spec.Size)
-		if err := c.removePod(pods[currentClusterSize-1].Name); err != nil {
-			return err
-		}
-		if err := c.updateConfigMap(); err != nil {
-			c.logger.Warningf("error updating the shared config map: %s", err)
+	if currentVersion != "" && currentVersion != desiredVersion {
+		// Report that we are upgrading the cluster's version.
+		c.cluster.Status.AppendUpgradingCondition(currentVersion, desiredVersion)
+		// Iterate over pods, upgrading them as necessary.
+		for _, pod := range pods {
+			if kubernetesutil.GetNATSVersion(pod) != c.cluster.Spec.Version {
+				kubernetesutil.SetNATSVersion(pod, c.cluster.Spec.Version)
+				c.maybeUpgradeMgmtService()
+				return c.upgradePod(pod)
+			}
 		}
 	}
 
-	return nil
-}
-
-func (c *Cluster) reconcileUpgrade(pods []*v1.Pod, cs v1alpha2.ClusterSpec) error {
-	c.logger.Warningf("Cluster version doesn't match, reconciling...")
-	pod := pickPodToUpgrade(pods, cs.Version)
-	kubernetesutil.SetNATSVersion(pod, cs.Version)
-	c.maybeUpgradeMgmtService()
-	return c.upgradePod(pod)
-}
-
-// needsUpgrade determines whether cluster needs upgrade or not.
-func needsUpgrade(pods []*v1.Pod, cs v1alpha2.ClusterSpec) bool {
-	return len(pods) == cs.Size && pickPodToUpgrade(pods, cs.Version) != nil
-}
-
-// pickPodToUpgrade selects the first pod, if any, which version doesn't
-// correspond to desired version.
-func pickPodToUpgrade(pods []*v1.Pod, newVersion string) *v1.Pod {
-	for _, pod := range pods {
-		if kubernetesutil.GetNATSVersion(pod) != newVersion {
-			return pod
-		}
-	}
+	// Update the reported cluster version before returning.
+	c.cluster.Status.SetCurrentVersion(desiredVersion)
 	return nil
 }

--- a/pkg/controller/generic.go
+++ b/pkg/controller/generic.go
@@ -118,3 +118,8 @@ func (c *genericController) enqueue(obj interface{}) {
 		c.workqueue.AddRateLimited(key)
 	}
 }
+
+// enqueueByCoordinates takes a namespace and a name and puts "namespace/name" onto the work queue.
+func (c *genericController) enqueueByCoordinates(namespace, name string) {
+	c.workqueue.AddRateLimited(fmt.Sprintf("%s/%s", namespace, name))
+}

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -15,15 +15,22 @@
 package kubernetes
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
-	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
-	"github.com/nats-io/nats-operator/pkg/constants"
-
+	"github.com/Azure/draft/pkg/kube/podutil"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	watchapi "k8s.io/apimachinery/pkg/watch"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/watch"
+
+	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
+	"github.com/nats-io/nats-operator/pkg/constants"
 )
 
 // natsPodContainer returns a NATS server pod container spec.
@@ -194,4 +201,50 @@ func PodSpecToPrettyJSON(pod *v1.Pod) (string, error) {
 		return "", err
 	}
 	return string(bytes), nil
+}
+
+// WaitUntilPodCondition establishes a watch on the specified pod and blocks until the specified condition function is satisfied.
+func WaitUntilPodCondition(kubeClient corev1.CoreV1Interface, pod *v1.Pod, fn watch.ConditionFunc) error {
+	// Create a selector that targets the specified pod.
+	fs := ByCoordinates(pod.Namespace, pod.Name)
+	// Grab a ListerWatcher with which we can watch the pod.
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fs.String()
+			return kubeClient.Pods(pod.Namespace).List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watchapi.Interface, error) {
+			options.FieldSelector = fs.String()
+			return kubeClient.Pods(pod.Namespace).Watch(options)
+		},
+	}
+	// Watch for updates to the specified pod until fn is satisfied.
+	last, err := watch.UntilWithSync(context.TODO(), lw, &v1.Pod{}, nil, fn)
+	if err != nil {
+		return err
+	}
+	if last == nil {
+		return fmt.Errorf("no events received for pod %q", ResourceKey(pod))
+	}
+	return nil
+}
+
+// isPodRunningAndReady returns whether the specified pod is running, ready and has its ".status.podIP" field populated.
+func isPodRunningAndReady(pod *v1.Pod) bool {
+	return pod.Status.Phase == v1.PodRunning && podutil.IsPodReady(pod) && pod.Status.PodIP != ""
+}
+
+// WaitUntilPodReady establishes a watch on the specified pod and blocks until the pod is running, ready and has its ".status.podIP" field populated.
+func WaitUntilPodReady(kubeClient corev1.CoreV1Interface, pod *v1.Pod) error {
+	return WaitUntilPodCondition(kubeClient, pod, func(event watchapi.Event) (bool, error) {
+		switch event.Type {
+		case watchapi.Error:
+			return false, fmt.Errorf("got event of type error: %+v", event.Object)
+		case watchapi.Deleted:
+			return false, fmt.Errorf("pod %q has been deleted", pod.Name)
+		default:
+			pod = event.Object.(*v1.Pod)
+			return isPodRunningAndReady(pod), nil
+		}
+	})
 }

--- a/pkg/util/strings/hash.go
+++ b/pkg/util/strings/hash.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The nats-operator Authors
+// Copyright 2018 The nats-operator Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kubernetes
+package strings
 
 import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/fields"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
 )
 
-// ByCoordinates returns a field selector that can be used to filter Kubernetes resources based on their name and namespace.
-func ByCoordinates(namespace, name string) fields.Selector {
-	return fields.ParseSelectorOrDie(fmt.Sprintf("metadata.name==%s,metadata.namespace==%s", name, namespace))
+// HashSlice creates an unique identifier for a given slice of strings.
+func HashSlice(s []string) string {
+	h := sha256.New()
+	h.Write([]byte(strings.Join(s[:], ",")))
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/test/e2e/e2eutil/crd.go
+++ b/test/e2e/e2eutil/crd.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-operator/pkg/client"
 	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
+	"github.com/nats-io/nats-operator/pkg/client"
 	kubernetesutil "github.com/nats-io/nats-operator/pkg/util/kubernetes"
 	"github.com/nats-io/nats-operator/pkg/util/retryutil"
 

--- a/test/e2e/e2eutil/wait.go
+++ b/test/e2e/e2eutil/wait.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-operator/pkg/constants"
 	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
+	"github.com/nats-io/nats-operator/pkg/constants"
 	kubernetesutil "github.com/nats-io/nats-operator/pkg/util/kubernetes"
 	"github.com/nats-io/nats-operator/pkg/util/retryutil"
 
@@ -255,7 +255,7 @@ func WaitUntilOperatorReady(kubecli corev1.CoreV1Interface, namespace, name stri
 func countRoutes(kubecli corev1.CoreV1Interface, namespace, name string) (int, error) {
 	// Check the "/routez" endpoint for the number of established routes.
 	b, err := kubecli.
-	    RESTClient().
+		RESTClient().
 		Get().
 		Namespace(namespace).
 		Resource("pods").

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -105,7 +105,7 @@ func (f *Framework) SetupNatsOperator() error {
 				{
 					Name:            "nats-operator",
 					Image:           f.opImage,
-					ImagePullPolicy: v1.PullAlways,
+					ImagePullPolicy: v1.PullIfNotPresent,
 					Command:         cmd,
 					Env: []v1.EnvVar{
 						{
@@ -130,7 +130,7 @@ func (f *Framework) SetupNatsOperator() error {
 					},
 				},
 			},
-			RestartPolicy: v1.RestartPolicyNever,
+			RestartPolicy:      v1.RestartPolicyNever,
 			ServiceAccountName: "nats-operator",
 		},
 	}

--- a/test/util/natscluster.go
+++ b/test/util/natscluster.go
@@ -1,0 +1,56 @@
+// Copyright 2017 The nats-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	watchapi "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/watch"
+
+	"github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
+	v1alpha2client "github.com/nats-io/nats-operator/pkg/client/clientset/versioned/typed/nats/v1alpha2"
+	"github.com/nats-io/nats-operator/pkg/util/kubernetes"
+)
+
+// WaitForNatsClusterCondition establishes a watch on the specified NatsCluster resource and blocks until the specified condition is satisfied.
+func WaitForNatsClusterCondition(natsClient *v1alpha2client.NatsV1alpha2Client, natsCluster *v1alpha2.NatsCluster, fn watch.ConditionFunc) error {
+	// Create a selector that targets the specified NatsCluster resource.
+	fs := kubernetes.ByCoordinates(natsCluster.Namespace, natsCluster.Name)
+	// Grab a ListerWatcher with which we can watch the pod.
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fs.String()
+			return natsClient.NatsClusters(natsCluster.Namespace).List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watchapi.Interface, error) {
+			options.FieldSelector = fs.String()
+			return natsClient.NatsClusters(natsCluster.Namespace).Watch(options)
+		},
+	}
+	// Watch for updates to the specified NatsCluster resource until fn is satisfied.
+	last, err := watch.UntilWithSync(context.TODO(), lw, &v1alpha2.NatsCluster{}, nil, fn)
+	if err != nil {
+		return err
+	}
+	if last == nil {
+		return fmt.Errorf("no events received for natscluster %q", natsCluster.Name)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR introduces support for using a [work queue](https://github.com/kubernetes/client-go/blob/master/util/workqueue/rate_limitting_queue.go) to distribute work among a number of worker threads (goroutines). This allows us to align with the [guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/controllers.md#guidelines) for writing a controller by transitioning between the following two models:

**Current (`master`):**

![nats-operator-master](https://user-images.githubusercontent.com/2365176/48366950-3b15a000-e6a7-11e8-94d7-9ddb5caff562.png)

**New (`rework`):**

![nats-operator-rework](https://user-images.githubusercontent.com/2365176/48366349-7f07a580-e6a5-11e8-9473-499e650e37ee.png)

By transitioning between these models, we reduce the number of goroutines required to handle `NatsCluster` resources from `N` (one per cluster) to a constant value `C` (currently `2`), and also reduce the load on the Kubernetes API by reducing the number of requests issued against it.

A key part of this transition involves switching from a model in which we do a "unit of work" (e.g. create a single pod) every 5s to a model where a worker goroutine does _all the work_ required at the moment (e.g. create two pods to achieve a total size of five), becoming available for working on other `NatsCluster` resources until the "current" `NatsCluster` needs to be reconciled again. The fact that a `NatsCluster` needs to be reconciled is signaled by its `namespace/name` being added to the workqueue. In its turn, this happens whenever one of the following situations occurs:

1. The `NatsCluster` resource is _seen_ (e.g. created, or listed when the application starts);
1. The `NatsCluster` resource is modified.
1. A pod, service, secret or `NatsServiceRole` associated with the `NatsCluster` is seen, modified or deleted.
1. The full resync period of the shared informer factories (currently set to 24h) elapses. This may be disabled in the future. 

To allow for this change, we now wait for a pod to be ready after creating it, as well as for a pod to be effectively deleted after it is deleted. The order and naming strategy for pods is kept, even though `createPod` and `removePod` are being reworked to play nicely with listers - speaking of which, we now also use listers instead of directly querying the API to know the current state of a given resource. This also helps greatly reduce our request footprint.

For more info on _edge_ vs _level_ triggered reconciliation, please read [this article](https://hackernoon.com/level-triggering-and-reconciliation-in-kubernetes-1f17fe30333d).