### PR TITLE
Create more strict rules for RBAC

### DIFF
--- a/deploy/default-rbac.yaml
+++ b/deploy/default-rbac.yaml
@@ -38,12 +38,20 @@ rules:
 # Allow actions on basic Kubernetes objects
 - apiGroups: [""]
   resources:
-  - configmaps
-  - secrets
-  - pods
   - services
   - serviceaccounts
   - serviceaccounts/token
-  - endpoints
+  verbs: ["get"]
+- apiGroups: [""]
+  resources:
   - events
-  verbs: ["*"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources:
+  - endpoints
+  - secrets
+  verbs: ["list", "get", "update"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "get", "create"]


### PR DESCRIPTION
I don't think this operator needs all verbs on these Kubernetes objects. We should make sure to have less access.

This is possible missing something as I have reverse engineered this, rather than actually read through the code.