### PR TITLE
Release/v0.3.0

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: nats-operator
       containers:
       - name: nats-operator
-        image: connecteverything/nats-operator:0.2.3-v1alpha2
+        image: connecteverything/nats-operator:0.3.0-v1alpha2
         imagePullPolicy: Always
         ports:
         - name: readyz

--- a/docker/operator/Dockerfile
+++ b/docker/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine3.8 AS builder
+FROM golang:1.11-alpine3.8 AS builder
 WORKDIR $GOPATH/src/github.com/nats-io/nats-operator/
 RUN apk add --update git
 RUN go get -u github.com/golang/dep/cmd/dep

--- a/example/deployment-rbac.yaml
+++ b/example/deployment-rbac.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: nats-operator
       containers:
       - name: nats-operator
-        image: connecteverything/nats-operator:0.2.3-v1alpha2
+        image: connecteverything/nats-operator:0.3.0-v1alpha2
         imagePullPolicy: Always
         ports:
         - name: readyz

--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: nats-operator
-        image: connecteverything/nats-operator:0.2.3-v1alpha2
+        image: connecteverything/nats-operator:0.3.0-v1alpha2
         imagePullPolicy: Always
         ports:
         - name: readyz

--- a/example/example-nats-cluster-metrics.yaml
+++ b/example/example-nats-cluster-metrics.yaml
@@ -1,0 +1,12 @@
+apiVersion: "nats.io/v1alpha2"
+kind: "NatsCluster"
+metadata:
+  name: "nats-cluster-metrics"
+spec:
+  size: 3
+  version: "1.3.0"
+  serverImage: "nats"
+  pod:
+    enableMetrics: true
+    metricsImage: "synadia/prometheus-nats-exporter"
+    metricsImageTag: "0.1.0"

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	OperatorVersion = "0.2.3-v1alpha2+git"
+	OperatorVersion = "0.3.0-v1alpha2+git"
 	GitSHA          = "Not provided"
 )


### PR DESCRIPTION
### Added

- Prometheus support added to the operator (https://github.com/nats-io/nats-operator/issues/40)

```yaml
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "nats-cluster-metrics"
spec:
  size: 3
  version: "1.3.0"
  serverImage: "nats"
  pod:
    enableMetrics: true
    metricsImage: "synadia/prometheus-nats-exporter"
    metricsImageTag: "0.1.0"
```

- Image can now be customized

```yaml
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "nats-cluster-custom"
spec:
  size: 3
  version: "1.3.0"
  serverImage: "my-org/nats"
```