### PR TITLE
e2e: kubernetes feature detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ install:
 
 before_script:
 - go version
-- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.10/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.12.3/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.30.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 - curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v0.18.0/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin/
-- sudo minikube start --vm-driver=none --kubernetes-version=v1.10.10 --feature-gates="TokenRequest=true,PodShareProcessNamespace=true" --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/apiserver.key --extra-config=apiserver.service-account-issuer=api --extra-config=apiserver.service-account-api-audiences=api --extra-config=apiserver.service-account-key-file=/var/lib/minikube/certs/sa.pub
+- sudo minikube start --vm-driver=none --kubernetes-version=v1.12.3 --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/apiserver.key --extra-config=apiserver.service-account-issuer=api --extra-config=apiserver.service-account-api-audiences=api
 - minikube update-context
 - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ NATS Operator manages NATS clusters atop [Kubernetes][k8s-home], automating thei
 
 ## Requirements
 
-- Kubernetes v1.8+
+- Kubernetes v1.10+.
+  - [Configuration reloading](#configuration-reload) is only supported in Kubernetes v1.12+.
+  - [Authentication using service accounts](#auth-service-accounts) is only supported in Kubernetes v1.12+ having the `TokenRequest` API enabled.
 
 ## Getting Started
 
@@ -172,22 +174,22 @@ $ kubectl create secret generic nats-clients-tls --from-file=ca.pem --from-file=
 
 ### Authorization
 
+<a name="auth-service-accounts"></a>
 #### Using ServiceAccounts
 
-The NATS Operator can define permissions based on Roles by using any
-present ServiceAccount in a namespace. To use this feature, it is
-necessary to use a Kubernetes +v1.10 cluster with the `TokenRequest`
-and `PodShareProcessNamespace` feature flags enabled.  To try this
-feature using `minikube` you can configure it to start as follows:
+The NATS Operator can define permissions based on Roles by using any present ServiceAccount in a namespace.
+This feature requires a Kubernetes v1.12+ cluster having the `TokenRequest` API enabled.
+To try this feature using `minikube` v0.30.0+, you can configure it to start as follows:
 
-```sh
-minikube start \
-  --feature-gates="TokenRequest=true,PodShareProcessNamespace=true" \
-  --extra-config=apiserver.service-account-signing-key-file=/var/lib/localkube/certs/apiserver.key \
+```console
+$ minikube start \
+  --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/apiserver.key \
   --extra-config=apiserver.service-account-issuer=api \
   --extra-config=apiserver.service-account-api-audiences=api \
-  --extra-config=apiserver.service-account-key-file=/var/lib/localkube/certs/sa.pub
+  --kubernetes-version=v1.12.3
 ```
+
+Please note that availability of this feature across Kubernetes offerings may vary widely.
 
 ServiceAccounts integration can then be enabled by setting the
 `enableServiceAccounts` flag to true in the `NatsCluster` configuration.
@@ -203,8 +205,10 @@ spec:
   version: "1.3.0"
 
   pod:
+    # NOTE: Only supported in Kubernetes v1.12+.
     enableConfigReload: true
   auth:
+    # NOTE: Only supported in Kubernetes v1.12+ clusters having the "TokenRequest" API enabled.
     enableServiceAccounts: true
 ```
 
@@ -357,14 +361,11 @@ spec:
     clientsAuthTimeout: 5
 ```
 
+<a name="configuration-reload"></a>
 ### Configuration Reload
 
-On Kubernetes +v1.10 clusters that have been started with support for
-sharing the process namespace (via `--feature-gates=PodShareProcessNamespace=true`),
-it is possible to enable on-the-fly reloading of configuration for the
-servers that are part of the cluster.  This can also be combined with the
-authorization support, so in case the user permissions change, then the
-servers will reload and apply the new permissions.
+On Kubernetes v1.12+ clusters it is possible to enable on-the-fly reloading of configuration for the servers that are part of the cluster.
+This can also be combined with the authorization support, so in case the user permissions change, then the servers will reload and apply the new permissions.
 
 ```yaml
 apiVersion: "nats.io/v1alpha2"
@@ -377,7 +378,7 @@ spec:
 
   pod:
     # Enable on-the-fly NATS Server config reload
-    # Note: only supported in Kubernetes clusters with PID namespace sharing enabled.
+    # NOTE: Only supported in Kubernetes v1.12+.
     enableConfigReload: true
 
     # Possible to customize version of reloader image

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -99,17 +99,16 @@ To stop execution and cleanup the deployment, hit `Ctrl+C`.
 ## Testing
 
 `nats-operator` includes an end-to-end test suite that is used to validate the implementation.
-As the test suite depends on having certain, advanced features enabled on the target Kubernetes cluster, Minikube is currently the only supported environment for running the test suite.
-To launch a Minikube cluster suitable for running the end-to-end test suite, you may run:
+Some tests require certain advanced features to be enabled on the target Kubernetes cluster.
+The test suite will do its best to perform feature detection on the target Kubernetes cluster and to skip tests that depend on these advanced features.
+To launch a Minikube cluster suitable for running the full end-to-end test suite, you may run:
 
 ```console
 $ minikube start \
     --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/apiserver.key \
     --extra-config=apiserver.service-account-issuer=api \
     --extra-config=apiserver.service-account-api-audiences=api \
-    --extra-config=apiserver.service-account-key-file=/var/lib/minikube/certs/sa.pub \
-    --feature-gates="TokenRequest=true,PodShareProcessNamespace=true" \
-    --kubernetes-version=v1.10.10
+    --kubernetes-version=v1.12.3
 ```
 
 Then, to run the test suite against the resulting Minikube cluster, you may simply run:

--- a/example/example-nats-cluster-auth.yaml
+++ b/example/example-nats-cluster-auth.yaml
@@ -7,8 +7,8 @@ spec:
   size: 3
   version: "1.3.0"
 
-  # On Kubernetes v1.10+ clusters with feature=`--feature-gates=PodShareProcessNamespace=true
   pod:
+    # NOTE: Only supported in Kubernetes v1.12+.
     enableConfigReload: true
 
     # Defaults but can be customized to be a different image

--- a/helm/nats-operator/values.yaml
+++ b/helm/nats-operator/values.yaml
@@ -99,8 +99,7 @@ readinessProbe:
 auth:
   enabled: true
 
-  ## To use this feature, it is necessary to use a Kubernetes +v1.10 cluster with 
-  ## the TokenRequest and PodShareProcessNamespace feature flags enabled
+  # NOTE: Only supported in Kubernetes v1.12+ clusters having the "TokenRequest" API enabled.
   enableServiceAccounts: false
   
   ## This is where you enter a username/password for 1 user
@@ -129,8 +128,7 @@ tls:
 clusterSize: 3
 
 ## Configuration Reload
-##
-## On Kubernetes v1.10+ clusters with feature=--feature-gates=PodShareProcessNamespace=true
+## NOTE: Only supported in Kubernetes v1.12+.
 configReload:
   enabled: false
   registry: "docker.io"

--- a/test/e2e/config_reload_test.go
+++ b/test/e2e/config_reload_test.go
@@ -26,11 +26,15 @@ import (
 	natsv1alpha2 "github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
 	"github.com/nats-io/nats-operator/pkg/conf"
 	"github.com/nats-io/nats-operator/pkg/util/kubernetes"
+	"github.com/nats-io/nats-operator/test/e2e/framework"
 )
 
 // TestConfigReloadOnResize creates a NatsCluster resource with size 1 and then scales it up to 3 members.
 // It then waits for a log message on the very first pod indicating that the configuration has been reloaded (since its configuration secret has been updated).
 func TestConfigReloadOnResize(t *testing.T) {
+	// Skip the test if "ShareProcessNamespace" is not enabled.
+	f.Require(t, framework.ShareProcessNamespace)
+
 	var (
 		initialSize = 1
 		finalSize   = 3
@@ -92,6 +96,9 @@ func TestConfigReloadOnResize(t *testing.T) {
 // Then, the test creates a NatsCluster resource that uses this secret for authentication, and makes sure that "user-1" can connect to the NATS cluster.
 // Finally, it removes the entry that corresponds to "user-1" from the authentication secret, and makes sure that "user-1" cannot connect to the NATS cluster anymore.
 func TestConfigReloadOnClientAuthSecretChange(t *testing.T) {
+	// Skip the test if "ShareProcessNamespace" is not enabled.
+	f.Require(t, framework.ShareProcessNamespace)
+
 	var (
 		username1 = "user-1"
 		username2 = "user-2"
@@ -226,6 +233,9 @@ func TestConfigReloadOnClientAuthSecretChange(t *testing.T) {
 // It then created the NatsCluster resource and verifies that "nsr1" cannot subscribe to the "hello.world" subject.
 // Finally, it adds "hello.world" to the list of allowed subjects for "nsr1" and verifies that "nsr1" can now subscribe to that subject.
 func TestConfigReloadOnNatsServiceRoleUpdates(t *testing.T) {
+	// Skip the test if "ShareProcessNamespace" or "TokenRequest" are not enabled.
+	f.Require(t, framework.ShareProcessNamespace, framework.TokenRequest)
+
 	var (
 		clusterName = "test-nats-nsr"
 		size        = 1

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1,0 +1,29 @@
+// Copyright 2017 The nats-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"testing"
+)
+
+// Require skips a test requiring features that are not enabled in the cluster.
+func (f *Framework) Require(t *testing.T, features ...ClusterFeature) {
+	for _, feature := range features {
+		if !f.ClusterFeatures[feature] {
+			t.Logf("skipping test as feature %q is not enabled in the cluster", feature)
+		}
+	}
+	t.SkipNow()
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -49,7 +49,9 @@ func init() {
 
 func TestMain(m *testing.M) {
 	f = framework.New(kubeconfig, namespace)
-	f.WaitForNatsOperator()
+	if err := f.WaitForNatsOperator(); err != nil {
+		panic(err)
+	}
 
 	if wait {
 		// Wait for the nats-operator-e2e pod to be running and start streaming logs until it terminates.
@@ -62,6 +64,8 @@ func TestMain(m *testing.M) {
 		// Exit with the same exit code as nats-operator-e2e.
 		os.Exit(c)
 	} else {
+		// Try to perform feature detection on the cluster.
+		f.FeatureDetect()
 		// Run the test suite.
 		os.Exit(m.Run())
 	}


### PR DESCRIPTION
This PR adds feature detection capabilities to the e2e test suite, so that we can conditionally skip tests that depend on the presence of:
- `TokenRequest` API, and
- PID namespace sharing.

It also updates `README.md` to suggest using Kubernetes v1.10+ (instead of Kubernetes v1.8+), and to explicitly require Kubernetes v1.12+ in order to use configuration reloading and service account authentication.

Finally, and as Minikube seems to better support Kubernetes v1.12.3 now, I updated our CI configuration to use this version when running the e2e test suite.