### PR TITLE
cmd: fix readiness probe

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -140,6 +140,10 @@ func main() {
 		logrus.Fatalf("error creating lock: %v", err)
 	}
 
+	// Signal that we're ready.
+	// We do it right before leader election so that we can use a "rolling update" strategy to update "nats-operator" while keeping unavailability to the bare minimum.
+	probe.SetReady()
+
 	leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
 		Lock:          rl,
 		LeaseDuration: 15 * time.Second,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -39,7 +39,6 @@ import (
 	"github.com/nats-io/nats-operator/pkg/cluster"
 	"github.com/nats-io/nats-operator/pkg/garbagecollection"
 	kubernetesutil "github.com/nats-io/nats-operator/pkg/util/kubernetes"
-	"github.com/nats-io/nats-operator/pkg/util/probe"
 )
 
 const (
@@ -233,9 +232,6 @@ func (c *Controller) Run(ctx context.Context) error {
 	}
 
 	c.logger.Info("started workers")
-
-	// Signal that we're ready and wait for the context to be canceled.
-	probe.SetReady()
 
 	// Block until the context is canceled.
 	<-ctx.Done()


### PR DESCRIPTION
Fixes #77

Before this PR, the operator would report readiness only after becoming leader. That means no operator instance would be ready if it wasn't leader, which would then break our rolling update strategy.

With this change, the operator instance reports readiness as soon as it's ready to become a leader.

It should be noted, though, that, due to the way leader election works, there will _always_ be temporary unavailability when updating. However, using a "rolling update" strategy instead of the "recreate" strategy (as suggested in #77) allows us to restrict this unavailability to the period between termination of the old leader and the moment when a new instance acquires the leadership lease.