### PR TITLE
Add annotations to nats cluster

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -127,6 +127,9 @@ type PodPolicy struct {
 	// Do not overwrite them.
 	Labels map[string]string `json:"labels,omitempty"`
 
+	// Annotations specifies the annotations to attach to pods the operator creates.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// NodeSelector specifies a map of key-value pairs. For the pod to be eligible
 	// to run on a node, the node must have each of the indicated key-value pairs as
 	// labels.

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -554,6 +554,8 @@ func NewNatsPodSpec(name, clusterName string, cs v1alpha2.ClusterSpec, owner met
 		LabelClusterNameKey:    clusterName,
 		LabelClusterVersionKey: cs.Version,
 	}
+	annotations := map[string]string{}
+
 	containers := make([]v1.Container, 0)
 	volumes := make([]v1.Volume, 0)
 	volumeMounts := make([]v1.VolumeMount, 0)
@@ -613,7 +615,7 @@ func NewNatsPodSpec(name, clusterName string, cs v1alpha2.ClusterSpec, owner met
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Labels:      labels,
-			Annotations: map[string]string{},
+			Annotations: annotations,
 		},
 		Spec: v1.PodSpec{
 			Hostname:      name,
@@ -770,8 +772,8 @@ func CreatePatch(o, n, datastruct interface{}) ([]byte, error) {
 	return strategicpatch.CreateTwoWayMergePatch(oldData, newData, datastruct)
 }
 
-// mergeLables merges l2 into l1. Conflicting label will be skipped.
-func mergeLabels(l1, l2 map[string]string) {
+// mergeMaps merges l2 into l1. Conflicting keys will be skipped.
+func mergeMaps(l1, l2 map[string]string) {
 	for k, v := range l2 {
 		if _, ok := l1[k]; ok {
 			continue

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -171,7 +171,8 @@ func applyPodPolicy(clusterName string, pod *v1.Pod, policy *v1alpha2.PodPolicy)
 		pod.Spec.Tolerations = policy.Tolerations
 	}
 
-	mergeLabels(pod.Labels, policy.Labels)
+	mergeMaps(pod.Labels, policy.Labels)
+	mergeMaps(pod.Annotations, policy.Annotations)
 
 	for i := range pod.Spec.Containers {
 		if pod.Spec.Containers[i].Name == "nats" {


### PR DESCRIPTION
Currently there is no way to propagate annotations from the nats cluster to the pods it creates.

This PR adds `Annotations` to the cluster spec which will be propagated to the pods it launches. 

It is helpfull for example when enabling istio in the same namespace as the nats-cluster, see https://github.com/nats-io/nats-operator/issues/88.
With this PR you can now specify
```yaml
pod:
  annotations:
    sidecar.istio.io/inject: "false"
```
to disable istio on your nats pods.