### PR TITLE
Add metrics port to mgmt service

### DIFF
--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -128,6 +128,12 @@ func CreateMgmtService(kubecli corev1client.CoreV1Interface, clusterName, cluste
 			TargetPort: intstr.FromInt(constants.MonitoringPort),
 			Protocol:   v1.ProtocolTCP,
 		},
+		{
+			Name:       "metrics",
+			Port:       constants.MetricsPort,
+			TargetPort: intstr.FromInt(constants.MetricsPort),
+			Protocol:   v1.ProtocolTCP,
+		},
 	}
 	selectors := LabelsForCluster(clusterName)
 	selectors[LabelClusterVersionKey] = clusterVersion


### PR DESCRIPTION
While adding prometheus annotations for metric scraping is good enough for the usual prometheus deployment, the prometheus operator requires a service target for its service monitor. 

https://github.com/coreos/kube-prometheus/pull/16#issuecomment-305933103

---

This PR exposes the `metrics` port on the nats mgmt svc, which can then be scraped by a `coreos ServiceMonitor`:
```yaml
---
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  labels:
    app: nats
  name: nats
spec:
  endpoints:
    - interval: 30s
      port: metrics
  jobLabel: nats
  selector:
    matchLabels:
      app: nats
```