### PR TITLE
test: fix skipping tests that do feature detection

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -23,7 +23,7 @@ func (f *Framework) Require(t *testing.T, features ...ClusterFeature) {
 	for _, feature := range features {
 		if !f.ClusterFeatures[feature] {
 			t.Logf("skipping test as feature %q is not enabled in the cluster", feature)
+			t.SkipNow()
 		}
 	}
-	t.SkipNow()
 }


### PR DESCRIPTION
This PR fixes a bug, introduced in #106, that causes tests that perform feature detection to be skipped.