### PR TITLE
Add support for host port and no advertise

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -29,9 +29,15 @@ import (
 )
 
 const (
-	// clientAuthSecretResourceVersionAnnotationKey is the key of the annotation that holds the last-observed resource version of the secret containing authentication data for the NATS cluster.
+	// clientAuthSecretResourceVersionAnnotationKey is the key of
+	// the annotation that holds the last-observed resource
+	// version of the secret containing authentication data for
+	// the NATS cluster.
 	clientAuthSecretResourceVersionAnnotationKey = "nats.io/cas"
-	// natsServiceRolesHashAnnotationKey is the key of the annotation that holds the hash of the comma-separated list of NatsServiceRole UIDs associated with the NATS cluster.
+
+	// natsServiceRolesHashAnnotationKey is the key of the
+	// annotation that holds the hash of the comma-separated list
+	// of NatsServiceRole UIDs associated with the NATS cluster.
 	natsServiceRolesHashAnnotationKey = "nats.io/nsr"
 )
 
@@ -56,7 +62,8 @@ type NatsCluster struct {
 	Status            ClusterStatus `json:"status"`
 }
 
-// GetGroupVersionKind returns a GroupVersionKind based on the current GroupVersion and the specified Kind.
+// GetGroupVersionKind returns a GroupVersionKind based on the current
+// GroupVersion and the specified Kind.
 func (c *NatsCluster) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind(CRDResourceKind)
 }
@@ -103,9 +110,14 @@ type ClusterSpec struct {
 	// Auth is the configuration to set permissions for users.
 	Auth *AuthConfig `json:"auth,omitempty"`
 
-	// LameDuckDurationSeconds is the number of seconds during which the server spreads the closing of clients when signaled to go into "lame duck mode".
+	// LameDuckDurationSeconds is the number of seconds during
+	// which the server spreads the closing of clients when
+	// signaled to go into "lame duck mode".
 	// +optional
 	LameDuckDurationSeconds *int64 `json:"lameDuckDurationSeconds,omitempty"`
+
+	// NoAdvertise disables advertising of endpoints for clients.
+	NoAdvertise bool `json:"noAdvertise,omitempty"`
 }
 
 // TLSConfig is the optional TLS configuration for the cluster.
@@ -174,6 +186,10 @@ type PodPolicy struct {
 
 	// MetricsImagePullPolicy is the pull policy for the prometheus metrics exporter image.
 	MetricsImagePullPolicy string `json:"metricsImagePullPolicy,omitempty"`
+
+	// ClientsHostPort will bind a host port for the NATS container clients port,
+	// also meaning that only a single NATS server can be running on that machine.
+	ClientsHostPort int `json:"clientsHostPort,omitempty"`
 }
 
 // AuthConfig is the authorization configuration for

--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -187,9 +187,9 @@ type PodPolicy struct {
 	// MetricsImagePullPolicy is the pull policy for the prometheus metrics exporter image.
 	MetricsImagePullPolicy string `json:"metricsImagePullPolicy,omitempty"`
 
-	// ClientsHostPort will bind a host port for the NATS container clients port,
+	// EnableClientsHostPort will bind a host port for the NATS container clients port,
 	// also meaning that only a single NATS server can be running on that machine.
-	ClientsHostPort int `json:"clientsHostPort,omitempty"`
+	EnableClientsHostPort bool `json:"enableClientsHostPort,omitempty"`
 }
 
 // AuthConfig is the authorization configuration for

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -578,7 +578,11 @@ func NewNatsPodSpec(name, clusterName string, cs v1alpha2.ClusterSpec, owner met
 	volumeMount = newNatsPidFileVolumeMount()
 	volumeMounts = append(volumeMounts, volumeMount)
 
-	container := natsPodContainer(clusterName, cs.Version, cs.ServerImage)
+	var enableClientsHostPort bool
+	if cs.Pod != nil {
+		enableClientsHostPort = cs.Pod.EnableClientsHostPort
+	}
+	container := natsPodContainer(clusterName, cs.Version, cs.ServerImage, enableClientsHostPort)
 	container = containerWithLivenessProbe(container, natsLivenessProbe())
 
 	// In case TLS was enabled as part of the NATS cluster

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -618,6 +618,10 @@ func NewNatsPodSpec(name, clusterName string, cs v1alpha2.ClusterSpec, owner met
 		"-P",
 		constants.PidFilePath,
 	}
+	if cs.NoAdvertise {
+		cmd = append(cmd, "--no_advertise")
+	}
+
 	container.Command = cmd
 	containers = append(containers, container)
 

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"testing"
+	"time"
 
 	natsv1alpha2 "github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
 )
@@ -115,5 +116,80 @@ func TestPauseControl(t *testing.T) {
 	defer fn()
 	if err = f.WaitUntilFullMeshWithVersion(ctx3, natsCluster, finalSize, version); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestCreateClusterWithHostPort creates a NatsCluster resource using
+// a host port with no advertise for clients.
+func TestCreateClusterWithHostPort(t *testing.T) {
+	var (
+		size    = 1
+		version = "1.3.0"
+	)
+
+	var (
+		natsCluster *natsv1alpha2.NatsCluster
+		err         error
+	)
+
+	// Create a NatsCluster resource with three members.
+	natsCluster, err = f.CreateCluster("test-nats-", size, version, func(natsCluster *natsv1alpha2.NatsCluster) {
+		natsCluster.Spec.Pod = &natsv1alpha2.PodPolicy{
+			EnableClientsHostPort: true,
+		}
+		natsCluster.Spec.NoAdvertise = true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make sure we cleanup the NatsCluster resource after we're done testing.
+	defer func() {
+		if err = f.DeleteCluster(natsCluster); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// List pods belonging to the NATS cluster, and make
+	// sure that every route is listed in the
+	// configuration.
+	var attempts int
+	for range time.NewTicker(1 * time.Second).C {
+		if attempts >= 30 {
+			t.Fatalf("Timed out waiting for pods with host port")
+		}
+		attempts++
+
+		pods, err := f.PodsForNatsCluster(natsCluster)
+		if err != nil {
+			continue
+		}
+		if len(pods) == 0 {
+			continue
+		}
+
+		var foundNoAdvertise bool
+		pod := pods[0]
+		container := pod.Spec.Containers[0]
+		for _, v := range container.Command {
+			if v == "--no_advertise" {
+				foundNoAdvertise = true
+			}
+		}
+		if !foundNoAdvertise {
+			t.Error("Container not configured with no advertise")
+		}
+
+		var foundHostPort bool
+		for _, port := range container.Ports {
+			if port.ContainerPort == int32(4222) && port.HostPort == int32(4222) {
+				foundHostPort = true
+			}
+		}
+		if !foundHostPort {
+			t.Error("Container not configured with host port")
+		}
+
+		break
 	}
 }

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -133,7 +133,7 @@ func TestCreateClusterWithHostPort(t *testing.T) {
 	)
 
 	// Create a NatsCluster resource with three members.
-	natsCluster, err = f.CreateCluster("test-nats-", size, version, func(natsCluster *natsv1alpha2.NatsCluster) {
+	natsCluster, err = f.CreateCluster(f.Namespace, "test-nats-", size, version, func(natsCluster *natsv1alpha2.NatsCluster) {
 		natsCluster.Spec.Pod = &natsv1alpha2.PodPolicy{
 			EnableClientsHostPort: true,
 		}

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -26,8 +26,10 @@ import (
 	"github.com/nats-io/nats-operator/pkg/constants"
 )
 
-// TestConfigContainsFullMesh creates a NatsCluster resource with size 3 and waits for the full mesh to be formed.
-// Then, it waits until the configuration secret has references to all pods belonging to the NatsCluster resource.
+// TestConfigContainsFullMesh creates a NatsCluster resource with size
+// 3 and waits for the full mesh to be formed.
+// Then, it waits until the configuration secret has references to all
+// pods belonging to the NatsCluster resource.
 func TestConfigContainsFullMesh(t *testing.T) {
 	var (
 		size    = 3
@@ -65,8 +67,11 @@ func TestConfigContainsFullMesh(t *testing.T) {
 	}
 }
 
-// TestExistingSecretIsReplaced creates a Secret containing a "nats.conf" entry with minimal configuration.
-// Then, it creates a NatsCluster resource with the same name and waits for the "nats.conf" entry to be replaced with the appropriate config.
+// TestExistingSecretIsReplaced creates a Secret containing a
+// "nats.conf" entry with minimal configuration.
+// Then, it creates a NatsCluster resource with the same name and
+// waits for the "nats.conf" entry to be replaced with the appropriate
+// config.
 func TestExistingSecretIsReplaced(t *testing.T) {
 	var (
 		size    = 3
@@ -90,7 +95,8 @@ func TestExistingSecretIsReplaced(t *testing.T) {
 		}
 	}()
 
-	// Create a NatsCluster resource, making sure that its name matches the name of the secret we've created above.
+	// Create a NatsCluster resource, making sure that its name
+	// matches the name of the secret we've created above.
 	natsCluster, err = f.CreateCluster(f.Namespace, "", size, version, func(natsCluster *natsv1alpha2.NatsCluster) {
 		natsCluster.Name = secret.Name
 	})
@@ -104,10 +110,15 @@ func TestExistingSecretIsReplaced(t *testing.T) {
 		}
 	}()
 
-	// We can't wait for the full mesh to be formed since the original configuration doesn't contain clustering configuration, and since configuration reloading is disabled.
-	// Hence, we just wait for all the required routes to show up on the "nats.conf" entry.
+	// We can't wait for the full mesh to be formed since the
+	// original configuration doesn't contain clustering
+	// configuration, and since configuration reloading is
+	// disabled.
+	// Hence, we just wait for all the required routes to show up
+	// on the "nats.conf" entry.
 
-	// Wait until the configuration file contains routes to all the pods (meaning it has been replaced).
+	// Wait until the configuration file contains routes to all
+	// the pods (meaning it has been replaced).
 	ctx1, fn := context.WithTimeout(context.Background(), waitTimeout)
 	defer fn()
 	if err = f.WaitUntilExpectedRoutesInConfig(ctx1, natsCluster); err != nil {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	// waitTimeout is the (default) amount of time we want to wait for certain conditions to be met.
+	// waitTimeout is the (default) amount of time we want to wait
+	// for certain conditions to be met.
 	waitTimeout = 2 * time.Minute
 )
 
@@ -39,11 +40,19 @@ var (
 
 	// featureGates is a comma-separated list of "key=value" pairs used to toggle certain features.
 	featureGates string
-	// kubeconfig is the path to the kubeconfig file to use when running the test suite outside a Kubernetes cluster (i.e. in "wait" mode).
+
+	// kubeconfig is the path to the kubeconfig file to use when
+	// running the test suite outside a Kubernetes cluster
+	// (i.e. in "wait" mode).
 	kubeconfig string
-	// namespace is the name of the Kubernetes namespace to use for running the test suite.
+
+	// namespace is the name of the Kubernetes namespace to use
+	// for running the test suite.
 	namespace string
-	// wait indicates whether we start in wait mode (i.e. instead of running the e2e test suite, connect to the kubernetes cluster and wait for the e2e job to complete).
+
+	// wait indicates whether we start in wait mode (i.e. instead
+	// of running the e2e test suite, connect to the kubernetes
+	// cluster and wait for the e2e job to complete).
 	wait bool
 )
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -77,7 +77,8 @@ func TestMain(m *testing.M) {
 	}
 
 	if wait {
-		// Wait for the nats-operator-e2e pod to be running and start streaming logs until it terminates.
+		// Wait for the nats-operator-e2e pod to be running
+		// and start streaming logs until it terminates.
 		c, err := f.WaitForNatsOperatorE2ePodTermination()
 		if err != nil {
 			panic(err)

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	OperatorVersion = "0.3.0-v1alpha2+git"
+	OperatorVersion = "0.4.2-v1alpha2+git"
 	GitSHA          = "Not provided"
 )


### PR DESCRIPTION
Adds support for host port to be able to bind a nats server to an external ip, plus support for disabling advertising the internal ips to clients that connect externally.

```yaml
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "example-nats-1"
spec:
  size: 3
  version: "1.4.0"
  noAdvertise: true
  pod:
    enableClientsHostPort: true
```