### PR TITLE
Enable Client Advertise for External IPs

### DIFF
--- a/cmd/bootconfig/main.go
+++ b/cmd/bootconfig/main.go
@@ -1,0 +1,64 @@
+// Copyright 2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/nats-io/nats-operator/pkg/bootconfig"
+	log "github.com/sirupsen/logrus"
+)
+
+func main() {
+	fs := flag.NewFlagSet("nats-pod-bootconfig", flag.ExitOnError)
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: nats-pod-bootconfig [options...]\n\n")
+		fs.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\n")
+	}
+
+	var opts *bootconfig.Options = &bootconfig.Options{}
+	var showHelp, showVersion bool
+	fs.BoolVar(&showHelp, "h", false, "Show help")
+	fs.BoolVar(&showVersion, "v", false, "Show version")
+	fs.StringVar(&opts.ClientAdvertiseFileName, "f", "client_advertise.conf", "File name where the client advertise address will be written into")
+	fs.StringVar(&opts.TargetTag, "t", "nats.io/node-external-ip", "Tag that will be looked up from a node")
+	fs.Parse(os.Args[1:])
+
+	switch {
+	case showHelp:
+		flag.Usage()
+		os.Exit(0)
+	case showVersion:
+		fmt.Fprintf(os.Stderr, "NATS Server Pod boot config v%s\n", bootconfig.Version)
+		os.Exit(0)
+	}
+	if os.Getenv("DEBUG") == "true" {
+		log.SetLevel(log.DebugLevel)
+	}
+	formatter := &log.TextFormatter{
+		FullTimestamp: true,
+	}
+	log.SetFormatter(formatter)
+
+	controller := bootconfig.NewController(opts)
+	log.Infof("Starting NATS Server boot config v%s", bootconfig.Version)
+	err := controller.Run(context.Background())
+	if err != nil && err != context.Canceled {
+		log.Fatalf(err.Error())
+	}
+}

--- a/deploy/00-prereqs.yaml
+++ b/deploy/00-prereqs.yaml
@@ -6,6 +6,7 @@ metadata:
   # Change to the name of the namespace where to install NATS Operator.
   # Alternatively, change to "nats-io" to perform a cluster-scoped deployment in supported versions.
   namespace: default
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -21,7 +22,10 @@ subjects:
   # Change to the name of the namespace where to install NATS Operator.
   # Alternatively, change to "nats-io" to perform a cluster-scoped deployment in supported versions.
   namespace: default
-# NOTE: When performing multiple namespace-scoped installations, all "nats-operator" service accounts (across the different namespaces) MUST be added to this binding.
+
+# NOTE: When performing multiple namespace-scoped installations, all
+# "nats-operator" service accounts (across the different namespaces)
+# MUST be added to this binding.
 #- kind: ServiceAccount
 #  name: nats-operator
 #  namespace: nats-io
@@ -29,6 +33,7 @@ subjects:
 #  name: nats-operator
 #  namespace: namespace-2
 #(...)
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -69,3 +74,33 @@ rules:
   - namespaces
   verbs:
   - list
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-server
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nats-server
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nats-server-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nats-server
+subjects:
+- kind: ServiceAccount
+  name: nats-server
+  namespace: default

--- a/docker/bootconfig/Dockerfile
+++ b/docker/bootconfig/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.11-alpine3.8 AS builder
+WORKDIR $GOPATH/src/github.com/nats-io/nats-operator/
+RUN apk add --update git
+RUN go get -u github.com/golang/dep/cmd/dep
+COPY . .
+RUN dep ensure -v -vendor-only
+RUN CGO_ENABLED=0 go build -o /nats-pod-bootconfig ./cmd/bootconfig/main.go
+
+FROM alpine:3.8
+COPY --from=builder /nats-pod-bootconfig /usr/local/bin/nats-pod-bootconfig
+CMD ["nats-pod-bootconfig"]

--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -190,6 +190,17 @@ type PodPolicy struct {
 	// EnableClientsHostPort will bind a host port for the NATS container clients port,
 	// also meaning that only a single NATS server can be running on that machine.
 	EnableClientsHostPort bool `json:"enableClientsHostPort,omitempty"`
+
+	// AdvertiseExternalIP will configure the client advertise address for a pod
+	// to be the external IP of the pod where it is running.
+	AdvertiseExternalIP bool `json:"advertiseExternalIP,omitempty"`
+
+	// BootConfigContainerImage is the image to use for the initialize
+	// container that generates config on the fly for the nats server.
+	BootConfigContainerImage string `json:"bootconfigImage,omitempty"`
+
+	// BootConfigContainerImageTag is the tag of the bootconfig container image.
+	BootConfigContainerImageTag string `json:"bootconfigImageTag,omitempty"`
 }
 
 // AuthConfig is the authorization configuration for

--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -118,6 +118,9 @@ type ClusterSpec struct {
 
 	// NoAdvertise disables advertising of endpoints for clients.
 	NoAdvertise bool `json:"noAdvertise,omitempty"`
+
+	// PodTemplate is the optional template to use for the pods.
+	PodTemplate *v1.PodTemplateSpec `json:"template,omitempty"`
 }
 
 // TLSConfig is the optional TLS configuration for the cluster.

--- a/pkg/apis/nats/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/nats/v1alpha2/zz_generated.deepcopy.go
@@ -78,6 +78,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PodTemplate != nil {
+		in, out := &in.PodTemplate, &out.PodTemplate
+		*out = new(v1.PodTemplateSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/bootconfig/boot.go
+++ b/pkg/bootconfig/boot.go
@@ -1,0 +1,130 @@
+// Copyright 2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootconfig
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes"
+	k8srestapi "k8s.io/client-go/rest"
+	k8sclientcmd "k8s.io/client-go/tools/clientcmd"
+)
+
+const Version = "0.5.0"
+
+type Options struct {
+	// TargetTag is the tag that will be looked up to find
+	// the public ip from the node.
+	TargetTag string
+
+	// ClientAdvertiseFileName is the name of the file where
+	// the advertise configuration will be written into.
+	ClientAdvertiseFileName string
+
+	// NoSignals marks whether to enable the signal handler.
+	NoSignals bool
+}
+
+// Controller for the boot config.
+type Controller struct {
+	// Start/Stop cancellation.
+	quit func()
+
+	// Client to interact with Kubernetes resources.
+	kc k8sclient.Interface
+
+	// opts is the set of options.
+	opts *Options
+}
+
+// NewController creates a new controller with the configuration.
+func NewController(opts *Options) *Controller {
+	return &Controller{
+		opts: opts,
+	}
+}
+
+// SetupClients takes the configuration and prepares the rest
+// clients that will be used to interact with the cluster objects.
+func (c *Controller) SetupClients(cfg *k8srestapi.Config) error {
+	kc, err := k8sclient.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	c.kc = kc
+	return nil
+}
+
+// Run starts the controller.
+func (c *Controller) Run(ctx context.Context) error {
+	var err error
+	var cfg *k8srestapi.Config
+	if kubeconfig := os.Getenv("KUBERNETES_CONFIG_FILE"); kubeconfig != "" {
+		cfg, err = k8sclientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else {
+		cfg, err = k8srestapi.InClusterConfig()
+	}
+	if err != nil {
+		return err
+	}
+	if err := c.SetupClients(cfg); err != nil {
+		return err
+	}
+
+	nodeName := os.Getenv("KUBERNETES_NODE_NAME")
+	if nodeName == "" {
+		return errors.New("Target node name is missing")
+	}
+	log.Infof("Pod running on node %q", nodeName)
+
+	node, err := c.kc.CoreV1().Nodes().Get(nodeName, k8smetav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	var ok bool
+	var externalAddress string
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == "ExternalIP" {
+			externalAddress = addr.Address
+			ok = true
+			break
+		}
+	}
+
+	// Fallback to use a label to find the external address.
+	if !ok {
+		externalAddress, ok = node.Labels[c.opts.TargetTag]
+		if !ok || len(externalAddress) == 0 {
+			return errors.New("Could not find external IP address.")
+		}
+	}
+	log.Infof("Pod is running on node with external IP: %s", externalAddress)
+
+	clientAdvertiseConfig := fmt.Sprintf("\nclient_advertise = \"%s\"\n\n", externalAddress)
+
+	err = ioutil.WriteFile(c.opts.ClientAdvertiseFileName, []byte(clientAdvertiseConfig), 0644)
+	if err != nil {
+		return fmt.Errorf("Could not write client advertise config: %s", err)
+	}
+	log.Infof("Successfully wrote to config to %q", c.opts.ClientAdvertiseFileName)
+
+	return nil
+}

--- a/pkg/conf/natsconf.go
+++ b/pkg/conf/natsconf.go
@@ -19,6 +19,7 @@ type ServerConfig struct {
 	MaxPayload       int                  `json:"max_payload,omitempty"`
 	Authorization    *AuthorizationConfig `json:"authorization,omitempty"`
 	LameDuckDuration string               `json:"lame_duck_duration,omitempty"`
+	Include          string               `json:"include,omitempty"`
 }
 
 type ClusterConfig struct {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -43,6 +43,10 @@ const (
 	// ConfigFilePath is the absolute path to the NATS config file.
 	ConfigFilePath = ConfigMapMountPath + "/" + ConfigFileName
 
+	// BootConfigFilePath is the path to the include file that
+	// contains the external IP address.
+	BootConfigFilePath = "advertise/client_advertise.conf"
+
 	// PidFileVolumeName is the name of the volume used for the NATS server pid file.
 	PidFileVolumeName = "pid"
 


### PR DESCRIPTION
Adds support for the NATS server container to be able to advertise the external IP address of the node where it is running on.   In order to do this, it relies on an extra initializer container named 'bootconfig' that queries the Kubernetes API with the name of the node injected as an environment variable, then writes it as a file which is then mounted as a volume by the pod and the loaded via the `include` directive from the NATS server configuration file.

Also a `template` parameter is added in order to be able to parameterize a `NatsCluster` a la `Deployment`s to be able to set a service account, which is required in order to be able to peek at the external IP metadata from the server.

A full example of this advanced configuration is below:

```yaml
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "nats-dev"
spec:
  size: 3
  version: "1.4.0"

  pod:
    enableClientsHostPort: true
    advertiseExternalIP: true
    bootconfigImage: "wallyqs/nats-boot-config"
    bootconfigImageTag: "0.5.0"

  template:
    spec:
      serviceAccountName: "nats-server"
```

Fixes #120 