### PR TITLE
Support https monitoring

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -145,6 +145,9 @@ type TLSConfig struct {
 	// RoutesSecret is the secret containing the certificates
 	// to secure the port to which cluster routes connect.
 	RoutesSecret string `json:"routesSecret,omitempty"`
+
+	// EnableHttps makes the monitoring endpoint use https.
+	EnableHttps bool `json:"enableHttps,omitempty"`
 }
 
 // PodPolicy defines the policy to create pod for the NATS container.

--- a/pkg/conf/natsconf.go
+++ b/pkg/conf/natsconf.go
@@ -10,6 +10,7 @@ type ServerConfig struct {
 	Host             string               `json:"host,omitempty"`
 	Port             int                  `json:"port,omitempty"`
 	HTTPPort         int                  `json:"http_port,omitempty"`
+	HTTPSPort        int                  `json:"https_port,omitempty"`
 	Cluster          *ClusterConfig       `json:"cluster,omitempty"`
 	TLS              *TLSConfig           `json:"tls,omitempty"`
 	Debug            bool                 `json:"debug,omitempty"`

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -148,6 +148,12 @@ func addTLSConfig(sconfig *natsconf.ServerConfig, cs v1alpha2.ClusterSpec) {
 		return
 	}
 
+	if cs.TLS.EnableHttps {
+		// Replace monitoring port with https one.
+		sconfig.HTTPSPort = int(constants.MonitoringPort)
+		sconfig.HTTPPort = 0
+	}
+
 	if cs.TLS.ServerSecret != "" {
 		sconfig.TLS = &natsconf.TLSConfig{
 			CAFile:   constants.ServerCAFilePath,
@@ -645,7 +651,7 @@ func NewNatsPodSpec(namespace, name, clusterName string, cs v1alpha2.ClusterSpec
 		enableClientsHostPort = cs.Pod.EnableClientsHostPort
 	}
 	container := natsPodContainer(clusterName, cs.Version, cs.ServerImage, enableClientsHostPort)
-	container = containerWithLivenessProbe(container, natsLivenessProbe())
+	container = containerWithLivenessProbe(container, natsLivenessProbe(cs))
 
 	// In case TLS was enabled as part of the NATS cluster
 	// configuration then should include the configuration here.

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -128,12 +128,17 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 	return c
 }
 
-func natsLivenessProbe() *v1.Probe {
+func natsLivenessProbe(cs v1alpha2.ClusterSpec) *v1.Probe {
+	action := &v1.HTTPGetAction{
+		Port: intstr.IntOrString{IntVal: constants.MonitoringPort},
+	}
+	if cs.TLS != nil && cs.TLS.EnableHttps {
+		action.Scheme = "HTTPS"
+	}
+
 	return &v1.Probe{
 		Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Port: intstr.IntOrString{IntVal: constants.MonitoringPort},
-			},
+			HTTPGet: action,
 		},
 		InitialDelaySeconds: 10,
 		TimeoutSeconds:      10,


### PR DESCRIPTION
Enables monitoring and liveness check using https for the monitoring endpoint:

```yaml
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "nats-cluster"
spec:
  # Number of nodes in the cluster
  size: 3
  version: "1.4.0"

  tls:
    enableHttps: true
    serverSecret: "nats-clients-tls"
```

Fixes #128 