### PR TITLE
Add verify and map auth support

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -239,8 +239,8 @@ type AuthConfig struct {
 	// allow to clients to send their auth credentials.
 	ClientsAuthTimeout int `json:"clientsAuthTimeout,omitempty"`
 
-	// EnableTLSAuth toggles the verify and map.
-	EnableTLSAuth bool `json:"enableTLSAuth,omitempty"`
+	// TLSVerifyAndMap toggles verify and map to auth based on TLS certs.
+	TLSVerifyAndMap bool `json:"tlsVerifyAndMap,omitempty"`
 }
 
 func (c *ClusterSpec) Validate() error {

--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -238,6 +238,9 @@ type AuthConfig struct {
 	// ClientsAuthTimeout is the time in seconds that the NATS server will
 	// allow to clients to send their auth credentials.
 	ClientsAuthTimeout int `json:"clientsAuthTimeout,omitempty"`
+
+	// EnableTLSAuth toggles the verify and map.
+	EnableTLSAuth bool `json:"enableTLSAuth,omitempty"`
 }
 
 func (c *ClusterSpec) Validate() error {

--- a/pkg/conf/natsconf.go
+++ b/pkg/conf/natsconf.go
@@ -38,6 +38,7 @@ type TLSConfig struct {
 	CipherSuites     []string `json:"cipher_suites,omitempty"`
 	CurvePreferences []string `json:"curve_preferences,omitempty"`
 	Timeout          float64  `json:"timeout,omitempty"`
+	VerifyAndMap     bool     `json:"verify_and_map,omitempty"`
 }
 
 type AuthorizationConfig struct {

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -168,6 +168,9 @@ func addTLSConfig(sconfig *natsconf.ServerConfig, cs v1alpha2.ClusterSpec) {
 			KeyFile:  constants.RoutesKeyFilePath,
 		}
 	}
+	if cs.Auth != nil && cs.Auth.EnableTLSAuth {
+		sconfig.TLS.VerifyAndMap = true
+	}
 }
 
 func addAuthConfig(

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -168,7 +168,7 @@ func addTLSConfig(sconfig *natsconf.ServerConfig, cs v1alpha2.ClusterSpec) {
 			KeyFile:  constants.RoutesKeyFilePath,
 		}
 	}
-	if cs.Auth != nil && cs.Auth.EnableTLSAuth {
+	if cs.Auth != nil && cs.Auth.TLSVerifyAndMap {
 		sconfig.TLS.VerifyAndMap = true
 	}
 }

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -137,12 +137,6 @@ func TestCreateClusterWithHTTPSConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	ctx2, fn := context.WithTimeout(context.Background(), waitTimeout)
-	defer fn()
-	if err = f.WaitUntilPodLogLineMatches(ctx2, natsCluster, 1, "https"); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestCreateClusterWithVerifyAndMap(t *testing.T) {
@@ -159,7 +153,7 @@ func TestCreateClusterWithVerifyAndMap(t *testing.T) {
 			RoutesSecret: "nats-routes-tls",
 		}
 		natsCluster.Spec.Auth = &natsv1alpha2.AuthConfig{
-			EnableTLSAuth: true,
+			TLSVerifyAndMap: true,
 		}
 	})
 	if err != nil {
@@ -194,12 +188,6 @@ func TestCreateClusterWithVerifyAndMap(t *testing.T) {
 			return false, nil
 		}
 		if len(pods) < 1 {
-			return false, nil
-		}
-		ctx2, fn := context.WithTimeout(context.Background(), waitTimeout)
-		defer fn()
-		err = f.WaitUntilPodLogLineMatches(ctx2, natsCluster, 1, "TLS required for client connections")
-		if err != nil {
 			return false, nil
 		}
 		return true, nil

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -144,3 +144,67 @@ func TestCreateClusterWithHTTPSConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCreateClusterWithVerifyAndMap(t *testing.T) {
+	natsCluster, err := f.CreateCluster(f.Namespace, "", 1, "", func(natsCluster *natsv1alpha2.NatsCluster) {
+		// The NatsCluster resource must be called "nats" in
+		// order for the pre-provisioned certificates to work.
+		natsCluster.Name = "nats-verify"
+		natsCluster.Spec.ServerImage = "wallyqs/nats-server"
+		natsCluster.Spec.Version = "edge-2.0.0-RC5"
+
+		// Enable TLS using pre-provisioned certificates.
+		natsCluster.Spec.TLS = &natsv1alpha2.TLSConfig{
+			ServerSecret: "nats-certs",
+			RoutesSecret: "nats-routes-tls",
+		}
+		natsCluster.Spec.Auth = &natsv1alpha2.AuthConfig{
+			EnableTLSAuth: true,
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make sure we cleanup the NatsCluster resource after we're done testing.
+	defer func() {
+		if err = f.DeleteCluster(natsCluster); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Wait until the full mesh is formed.
+	ctx1, fn := context.WithTimeout(context.Background(), waitTimeout)
+	defer fn()
+	err = f.WaitUntilSecretCondition(ctx1, natsCluster, func(event watchapi.Event) (bool, error) {
+		secret := event.Object.(*v1.Secret)
+		conf, ok := secret.Data[constants.ConfigFileName]
+		if !ok {
+			return false, nil
+		}
+		config, err := natsconf.Unmarshal(conf)
+		if err != nil {
+			return false, nil
+		}
+		if config.TLS == nil || !config.TLS.VerifyAndMap {
+			return false, nil
+		}
+
+		pods, err := f.PodsForNatsCluster(natsCluster)
+		if err != nil {
+			return false, nil
+		}
+		if len(pods) < 1 {
+			return false, nil
+		}
+		ctx2, fn := context.WithTimeout(context.Background(), waitTimeout)
+		defer fn()
+		err = f.WaitUntilPodLogLineMatches(ctx2, natsCluster, 1, "TLS required for client connections")
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Enables verify and map support that is available in edge from the [nats server](https://github.com/nats-io/gnatsd#tls-authorization)

```yaml
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "nats-cluster"
spec:
  size: 3
  serverImage: "wallyqs/nats-server"
  version: "edge-2.0.0-RC5"

  tls:
    serverSecret: "nats-clients-tls"

  auth:
    tlsVerifyAndMap: true
    clientsAuthSecret: "nats-clients-auth"
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>