### PR TITLE
Add support for allow/deny permissions

### DIFF
--- a/example/clients-auth-permissions.json
+++ b/example/clients-auth-permissions.json
@@ -1,12 +1,21 @@
 {
   "users": [
-    { "username": "user1", "password": "user1secret" },
-    { "username": "user2", "password": "user2secret",
-      "permissions": {
-	"publish": ["hello.*"],
-	"subscribe": ["hello.world"]
+      { "username": "user0", "password": "user0secret",
+	"permissions": {
+	    "publish": {
+		"allow": ["public.>"],
+		"deny": ["private.>"]
+	    }
+	}
+      },
+      { "username": "user1", "password": "user1secret"
+      },
+      { "username": "user2", "password": "user2secret",
+	"permissions": {
+	    "publish": ["hello.*"],
+	    "subscribe": ["hello.world"]
+	}
       }
-    }
   ],
   "default_permissions": {
     "publish": ["SANDBOX.*"],

--- a/pkg/conf/natsconf.go
+++ b/pkg/conf/natsconf.go
@@ -63,8 +63,9 @@ type User struct {
 // Permissions are the allowed subjects on a per
 // publish or subscribe basis.
 type Permissions struct {
-	Publish   []string `json:"publish,omitempty"`
-	Subscribe []string `json:"subscribe,omitempty"`
+	// Can be either a map with allow/deny or an array.
+	Publish   interface{} `json:"publish,omitempty"`
+	Subscribe interface{} `json:"subscribe,omitempty"`
 }
 
 // Marshal takes a server configuration and returns its

--- a/pkg/conf/natsconf_test.go
+++ b/pkg/conf/natsconf_test.go
@@ -12,16 +12,19 @@ func TestConfMarshal(t *testing.T) {
 		err    error
 	}{
 		{
-			input:  &ServerConfig{},
-			output: "{}",
-			err:    nil,
+			input: &ServerConfig{},
+			output: `{
+  "logtime": false
+}`,
+			err: nil,
 		},
 		{
 			input: &ServerConfig{
 				HTTPPort: 8222,
 			},
 			output: `{
-  "http_port": 8222
+  "http_port": 8222,
+  "logtime": false
 }`,
 			err: nil,
 		},
@@ -30,7 +33,8 @@ func TestConfMarshal(t *testing.T) {
 				Port: 4222,
 			},
 			output: `{
-  "port": 4222
+  "port": 4222,
+  "logtime": false
 }`,
 			err: nil,
 		},
@@ -41,15 +45,18 @@ func TestConfMarshal(t *testing.T) {
 			},
 			output: `{
   "port": 4222,
-  "http_port": 8222
+  "http_port": 8222,
+  "logtime": false
 }`,
 			err: nil,
 		},
 		{
 			input: &ServerConfig{
 				LameDuckDuration: "2m",
+				Logtime:          true,
 			},
 			output: `{
+  "logtime": true,
   "lame_duck_duration": "2m"
 }`,
 		},
@@ -66,7 +73,8 @@ func TestConfMarshal(t *testing.T) {
   "http_port": 8222,
   "cluster": {
     "port": 6222
-  }
+  },
+  "logtime": false
 }`,
 			err: nil,
 		},
@@ -93,7 +101,8 @@ func TestConfMarshal(t *testing.T) {
       "nats://nats-2.default.svc:6222",
       "nats://nats-3.default.svc:6222"
     ]
-  }
+  },
+  "logtime": false
 }`,
 			err: nil,
 		},
@@ -124,7 +133,8 @@ func TestConfMarshal(t *testing.T) {
     ]
   },
   "debug": true,
-  "trace": true
+  "trace": true,
+  "logtime": false
 }`,
 			err: nil,
 		},
@@ -161,7 +171,8 @@ func TestConfMarshal(t *testing.T) {
       "cert_file": "/etc/nats-tls/server.pem",
       "key_file": "/etc/nats-tls/server-key.pem"
     }
-  }
+  },
+  "logtime": false
 }`,
 			err: nil,
 		},
@@ -179,6 +190,7 @@ func TestConfMarshal(t *testing.T) {
 			output: `{
   "port": 4222,
   "http_port": 8222,
+  "logtime": false,
   "authorization": {
     "default_permissions": {
       "publish": [
@@ -192,6 +204,46 @@ func TestConfMarshal(t *testing.T) {
 }`,
 			err: nil,
 		},
+		{
+			input: &ServerConfig{
+				Authorization: &AuthorizationConfig{
+					DefaultPermissions: &Permissions{
+						Publish: map[string][]string{
+							"allow": []string{"hello", "world"},
+							"deny":  []string{"foo.*", "bar.>"},
+						},
+						Subscribe: map[string][]string{
+							"allow": []string{"hi", "everyone"},
+						},
+					},
+				},
+			},
+			output: `{
+  "logtime": false,
+  "authorization": {
+    "default_permissions": {
+      "publish": {
+        "allow": [
+          "hello",
+          "world"
+        ],
+        "deny": [
+          "foo.*",
+          "bar.>"
+        ]
+      },
+      "subscribe": {
+        "allow": [
+          "hi",
+          "everyone"
+        ]
+      }
+    }
+  }
+}`,
+
+			err: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -202,7 +254,7 @@ func TestConfMarshal(t *testing.T) {
 			}
 			o := strings.TrimSpace(string(res))
 			if o != tt.output {
-				t.Errorf("Unexpected output: %v", o)
+				t.Errorf("Expected %+v, got: %+v", tt.output, o)
 			}
 		})
 	}

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -378,6 +378,8 @@ func CreateConfigSecret(kubecli corev1client.CoreV1Interface, operatorcli natsal
 		sconfig.MaxSubscriptions = cluster.ServerConfig.MaxSubscriptions
 		sconfig.MaxControlLine = cluster.ServerConfig.MaxControlLine
 		sconfig.Logtime = !cluster.ServerConfig.DisableLogtime
+	} else {
+		sconfig.Logtime = true
 	}
 
 	if cluster.ExtraRoutes != nil {
@@ -507,6 +509,8 @@ func UpdateConfigSecret(
 		sconfig.MaxSubscriptions = cluster.ServerConfig.MaxSubscriptions
 		sconfig.MaxControlLine = cluster.ServerConfig.MaxControlLine
 		sconfig.Logtime = !cluster.ServerConfig.DisableLogtime
+	} else {
+		sconfig.Logtime = true
 	}
 
 	if cluster.Pod != nil && cluster.Pod.AdvertiseExternalIP {


### PR DESCRIPTION
- Updates Permissions from JSON based secret to be able to load allow/deny permission rules.
- Includes bug fix for disabled logtime by default

Fixes #70 