### PR TITLE
Use camel case for custom server config

### DIFF
--- a/example/example-nats-custom-config.yaml
+++ b/example/example-nats-custom-config.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: "nats.io/v1alpha2"
+kind: "NatsCluster"
+metadata:
+  name: "nats-custom"
+spec:
+  size: 3
+  version: "1.4.1"
+
+  natsConfig:
+    debug: true
+    trace: true
+
+    # Duration within quotes
+    writeDeadline: "5s" 
+
+    # In bytes, in this case 5MB
+    maxPayload: 5242880
+
+    maxConnections: 10
+    maxSubscriptions: 10
+    maxPending: 1024 # In bytes
+    disableLogtime: true
+    maxControlLine: 2048
+    
+  pod:
+    # NOTE: Only supported in Kubernetes v1.12+.
+    enableConfigReload: true
+
+    # Defaults but can be customized to be a different image
+    reloaderImage: "connecteverything/nats-server-config-reloader"
+    reloaderImageTag: "0.2.2-v1alpha2"
+    reloaderImagePullPolicy: "IfNotPresent"

--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -135,12 +135,12 @@ type ServerConfig struct {
 	Debug            bool   `json:"debug,omitempty"`
 	Trace            bool   `json:"trace,omitempty"`
 	WriteDeadline    string `json:"write_deadline,omitempty"`
-	MaxConnections   int    `json:"max_connections,omitempty"`
-	MaxPayload       int    `json:"max_payload,omitempty"`
-	MaxPending       int    `json:"max_pending,omitempty"`
-	MaxSubscriptions int    `json:"max_subscriptions,omitempty"`
-	MaxControlLine   int    `json:"max_control_line,omitempty"`
-	DisableLogtime   bool   `json:"disable_logtime,omitempty"`
+	MaxConnections   int    `json:"maxConnections,omitempty"`
+	MaxPayload       int    `json:"maxPayload,omitempty"`
+	MaxPending       int    `json:"maxPending,omitempty"`
+	MaxSubscriptions int    `json:"maxSubscriptions,omitempty"`
+	MaxControlLine   int    `json:"maxControlLine,omitempty"`
+	DisableLogtime   bool   `json:"disableLogtime,omitempty"`
 }
 
 // ExtraRoute is a route that is not originally part of the NatsCluster

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The nats-operator Authors
+// Copyright 2017-2019 The nats-operator Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,6 @@
 package version
 
 var (
-	OperatorVersion = "0.4.2-v1alpha2+git"
+	OperatorVersion = "0.4.3-v1alpha2+git"
 	GitSHA          = "Not provided"
 )


### PR DESCRIPTION
In a previous PR, support for tuning some fields of the NATS server config was added but using snake case.  Switching to camel case in this PR to be consistent with rest of config from the cluster.

```yaml
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "nats-custom"
spec:
  size: 3
  version: "1.4.1"

   natsConfig:
    debug: true
    trace: true

     # Duration within quotes
    writeDeadline: "5s" 

     # In bytes, in this case 5MB
    maxPayload: 5242880

    maxConnections: 10
    maxSubscriptions: 10
    maxPending: 1024 # In bytes
    disableLogtime: true
    maxControlLine: 2048
```