### PR TITLE
Helm: do not a single user/password when multiple user/password

### DIFF
--- a/helm/nats-operator/config/client-auth.json
+++ b/helm/nats-operator/config/client-auth.json
@@ -1,6 +1,6 @@
 {
   "users": [
-    {{- if .Values.auth.username }}
+    {{- if and (.Values.auth.username) (not .Values.auth.users) }}
     { 
       "username": "{{ .Values.auth.username }}",
       "password": "{{ .Values.auth.password }}"


### PR DESCRIPTION
I wanted to define multiple user/passwords but that generated a bad secret:
```
{                                   
  "users": [                
    {                                 
      "username": "my-user",           
      "password": "T0pS3cr3t"                            
    }                                             
                                                                                      
    {                                                                                                                                                                                                              
      "username": "admin",                                                                                                                                                                                         
      "password": "xxx", 
      "permissions": {"publish":[">"],"subscribe":[">"]}                                                 
    },                                                                                                                                                                                                            
    {                                                                                                                                                                                                             
      "username": "ghstats",                                         
      "password": "xxxx",                                              
      "permissions": {"publish":["ghstats.*"],"subscribe":["ghstats.foobar"]}
    }                                                                                          
  ]                                               
} 
```
This small change allows to define multiple user/passwords