### PR TITLE
Add fields to extend TLS timeout

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -165,6 +165,14 @@ type TLSConfig struct {
 
 	// EnableHttps makes the monitoring endpoint use https.
 	EnableHttps bool `json:"enableHttps,omitempty"`
+
+	// ClientsTLSTimeout is the time in seconds that the NATS server will
+	// allow to clients to finish the TLS handshake.
+	ClientsTLSTimeout float64 `json:"clientsTLSTimeout,omitempty"`
+
+	// RoutesTLSTimeout is the time in seconds that the NATS server will
+	// allow to routes to finish the TLS handshake.
+	RoutesTLSTimeout float64 `json:"routesTLSTimeout,omitempty"`
 }
 
 // PodPolicy defines the policy to create pod for the NATS container.

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -160,12 +160,19 @@ func addTLSConfig(sconfig *natsconf.ServerConfig, cs v1alpha2.ClusterSpec) {
 			CertFile: constants.ServerCertFilePath,
 			KeyFile:  constants.ServerKeyFilePath,
 		}
+
+		if cs.TLS.ClientsTLSTimeout > 0 {
+			sconfig.TLS.Timeout = cs.TLS.ClientsTLSTimeout
+		}
 	}
 	if cs.TLS.RoutesSecret != "" {
 		sconfig.Cluster.TLS = &natsconf.TLSConfig{
 			CAFile:   constants.RoutesCAFilePath,
 			CertFile: constants.RoutesCertFilePath,
 			KeyFile:  constants.RoutesKeyFilePath,
+		}
+		if cs.TLS.RoutesTLSTimeout > 0 {
+			sconfig.Cluster.TLS.Timeout = cs.TLS.RoutesTLSTimeout
 		}
 	}
 	if cs.Auth != nil && cs.Auth.TLSVerifyAndMap {


### PR DESCRIPTION
Adds options to be able to extend the TLS timeout:

```yaml
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "nats"
spec:
  size: 3
  tls:
    serverSecret: "nats-clients-tls"
    routesSecret: "nats-routes-tls"

    clientsTLSTimeout: 5
    routesTLSTimeout: 5
```

Fixes #153 
Signed-off-by: Waldemar Quevedo <wally@synadia.com>