### PR TITLE
Allow Pod Template to provide initContainers, Volumes, and Containers

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -245,6 +245,9 @@ type PodPolicy struct {
 
 	// BootConfigContainerImageTag is the tag of the bootconfig container image.
 	BootConfigContainerImageTag string `json:"bootconfigImageTag,omitempty"`
+
+	// VolumeMounts is a list of k8s volume mount definitions for the nats container
+	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 }
 
 // AuthConfig is the authorization configuration for


### PR DESCRIPTION
Previously, `NewNatsPodSpec` would initialize it the spec from a deep
copy of the PodTemplate, if it was provided by the user.  However, it then
overwrites initContainers, Volumes, and Containers with item lists that
are build at runtime.

This commit changes the behavior to append to the existing lists, enabling
InitContainers, Volumes, and Containers to be specified in the pod template.

Additionally, this adds a `VolumeMounts` item to the PodPolicy so that
volumes provided in the template, can be mounted into the nats container.

Step #1 of addressing https://github.com/nats-io/nats-operator/issues/156