### PR TITLE
Bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License Apache 2.0](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Build Status](https://travis-ci.org/nats-io/nats-operator.svg?branch=master)](https://travis-ci.org/nats-io/nats-operator)
-[![Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=go&type=5&v=0.4.2)](https://github.com/nats-io/nats-operator/releases/tag/v0.4.3)
+[![Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=go&type=5&v=0.4.4)](https://github.com/nats-io/nats-operator/releases/tag/v0.4.4)
 
 NATS Operator manages NATS clusters atop [Kubernetes][k8s-home], automating their creation and administration.
 

--- a/deploy/10-deployment.yaml
+++ b/deploy/10-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: nats-operator
       containers:
       - name: nats-operator
-        image: connecteverything/nats-operator:0.4.3-v1alpha2
+        image: connecteverything/nats-operator:0.4.4-v1alpha2
         imagePullPolicy: IfNotPresent
         args:
         - nats-operator


### PR DESCRIPTION
### Added

- Add fields to extend TLS timeout  (https://github.com/nats-io/nats-operator/pull/154)

### Changed

- Reversed order of CRD init operations (https://github.com/nats-io/nats-operator/pull/155)

- Updated metrics prometheus-nats-exporter to version 0.2.0,
  add channelz and serverz to the arguments of the metrics container (#151)

### Fixed

- Bugfix for issue of service role tokens being deleted when same used multiple times (https://github.com/nats-io/nats-operator/issues/129)

### Removed

- Removed garbage collection code, rely on cascade delete done by K8S on objects (ownership references) (#150)

Signed-off-by: Waldemar Quevedo <wally@synadia.com>