### PR TITLE
Add few missing watch RBAC permissions

### DIFF
--- a/deploy/00-prereqs.yaml
+++ b/deploy/00-prereqs.yaml
@@ -59,19 +59,19 @@ rules:
 - apiGroups: [""]
   resources:
   - pods
-  verbs: ["create", "get", "patch", "update", "delete", "list"]
+  verbs: ["create", "watch", "get", "patch", "update", "delete", "list"]
 
 # Allowed actions on Services
 - apiGroups: [""]
   resources:
   - services
-  verbs: ["create", "get", "patch", "update", "delete", "list"]
+  verbs: ["create", "watch", "get", "patch", "update", "delete", "list"]
 
 # Allowed actions on Secrets
 - apiGroups: [""]
   resources:
   - secrets
-  verbs: ["create", "get", "update", "delete", "list"]
+  verbs: ["create", "watch", "get", "update", "delete", "list"]
 
 # Allow all actions on some special subresources
 - apiGroups: [""]
@@ -87,14 +87,13 @@ rules:
   resources:
   - namespaces
   - serviceaccounts
-  verbs:
-  - list
+  verbs: ["list", "get", "watch"]
 
 # Allow actions on Endpoints
 - apiGroups: [""]
   resources:
   - endpoints
-  verbs: ["get", "list", "update"]
+  verbs: ["create", "watch", "get", "update", "delete", "list"]
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Adds some missing perms that were only applied to the helm chart: https://github.com/nats-io/nats-operator/pull/148/files

Signed-off-by: Waldemar Quevedo <wally@synadia.com>