### PR TITLE
Refactor Helm Chart and make it possible to customize NATS Cluster

### DIFF
--- a/helm/nats-operator/Chart.yaml
+++ b/helm/nats-operator/Chart.yaml
@@ -1,5 +1,5 @@
 name: nats-operator
-version: 0.0.1
+version: 0.1.0
 appVersion: 0.2.3
 description: Nats operator creates/configures/manages nats clusters atop Kubernetes
 keywords:

--- a/helm/nats-operator/README.md
+++ b/helm/nats-operator/README.md
@@ -1,7 +1,8 @@
 # NATS Operator Helm Chart
 
-NATS is an open-source, cloud-native messaging system. Companies like Apcera, Baidu, Siemens, VMware, HTC, and Ericsson rely on NATS for its highly performant and resilient messaging capabilities.
-
+NATS is an open-source, cloud-native messaging system. Companies like Apcera,
+Baidu, Siemens, VMware, HTC, and Ericsson rely on NATS for its highly performant
+and resilient messaging capabilities.
 
 ## TL;DR
 
@@ -11,14 +12,19 @@ $ helm install .
 
 ## Introduction
 
-NATS Operator manages [NATS](https://nats.io/) clusters atop [Kubernetes](http://kubernetes.io), automating their creation and administration. With the NATS Operator you can benefits from the flexibility brought by the Kubernetes operator pattern. It means less juggling between manifests and a few handy features like automatic configuration reload.
+NATS Operator manages [NATS](https://nats.io/) clusters atop
+[Kubernetes](http://kubernetes.io), automating their creation and
+administration. With the NATS Operator you can benefits from the flexibility
+brought by the Kubernetes operator pattern. It means less juggling between
+manifests and a few handy features like automatic configuration reload.
 
-If you want to manage NATS entirely by yourself and have more control over your NATS cluster, you can always use the original [NATS](https://github.com/helm/charts/tree/master/stable/nats) Helm chart.
-
+If you want to manage NATS entirely by yourself and have more control over your
+NATS cluster, you can always use the original
+[NATS](https://github.com/helm/charts/tree/master/stable/nats) Helm chart.
 
 ## Prerequisites
 
-- Kubernetes 1.8+
+- Kubernetes 1.8+ (1.12 for some functionality)
 
 ## Installing the Chart
 
@@ -28,7 +34,9 @@ To install the chart with the release name `my-release`:
 $ helm install --name my-release .
 ```
 
-The command deploys NATS and the NATS Operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys NATS and the NATS Operator on the Kubernetes cluster in the
+default configuration. The [configuration](#configuration) section lists the
+parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -40,68 +48,73 @@ To uninstall/delete the `my-release` deployment:
 $ helm delete my-release
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
 
 ## Configuration
 
-The following table lists the configurable parameters of the NATS chart and their default values.
+The following table lists the configurable parameters of the NATS chart and
+their default values.
 
 | Parameter                            | Description                                                                                  | Default                                         |
 | ------------------------------------ | -------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `rbacEnabled`                        | Switch to enable/disable RBAC for this chart                                                 | `true`                                          |
-| `natsClusterVersion`                 | Version of the NATS server                                                                   | `1.4.1`                                         |
-| `image.registry`                     | NATS Operator image registry                                                                 | `docker.io`                                     |
-| `image.repository`                   | NATS Operator image name                                                                     | `connecteverything/nats-operator`               |
-| `image.tag`                          | NATS Operator image tag                                                                      | `0.4.3-v1alpha2`                                |
-| `image.pullPolicy`                   | Image pull policy                                                                            | `Always`                                        |
-| `image.pullSecrets`                  | Specify image pull secrets                                                                   | `nil`                                           |
-| `securityContext.enabled`            | Enable security context                                                                      | `true`                                          |
-| `securityContext.fsGroup`            | Group ID for the container                                                                   | `1001`                                          |
-| `securityContext.runAsUser`          | User ID for the container                                                                    | `1001`                                          |
-| `nodeSelector`                       | Node labels for pod assignment                                                               | `nil`                                           |
-| `tolerations`                        | Toleration labels for pod assignment                                                         | `nil`                                           |
-| `schedulerName`                      | Name of an alternate scheduler                                                               | `nil`                                           |
-| `antiAffinity`                       | Anti-affinity for pod assignment (values: soft or hard)                                      | `soft`                                          |
-| `podAnnotations`                     | Annotations to be added to pods                                                              | `{}`                                            |
-| `podLabels`                          | Additional labels to be added to pods                                                        | `{}`                                            |
-| `updateStrategy`                     | Replicaset Update strategy                                                                   | `OnDelete`                                      |
-| `rollingUpdatePartition`             | Partition for Rolling Update strategy                                                        | `nil`                                           |
-| `resources`                          | CPU/Memory resource requests/limits                                                          | `{}`                                            |
-| `livenessProbe.enabled`              | Enable liveness probe                                                                        | `true`                                          |
-| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                     | `30`                                            |
-| `livenessProbe.periodSeconds`        | How often to perform the probe                                                               | `10`                                            |
-| `livenessProbe.timeoutSeconds`       | When the probe times out                                                                     | `5`                                             |
-| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                             |
-| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                             |
-| `readinessProbe.enabled`             | Enable readiness probe                                                                       | `true`                                          |
-| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                    | `5`                                             |
-| `readinessProbe.periodSeconds`       | How often to perform the probe                                                               | `10`                                            |
-| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                     | `5`                                             |
-| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                             |
-| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                             |
-| `auth.enabled`                       | Switch to enable/disable client authentication                                               | `true`                                          |
-| `auth.enableServiceAccounts`         | Enable ServiceAccounts permissions                                                           | `false`                                         |
-| `auth.username`                      | Client authentication username                                                               | `true`                                          |
-| `auth.password`                      | Client authentication password                                                               | `true`                                          |
-| `auth.users`                         | Allows multi-user authentication of 2 or more user                                           | `[]`                                            |
-| `auth.defaultPermissions`            | Enable default permissions for users                                                         | `{}`                                            |
-| `auth.defaultPermissions.publish`    | Default permission for publish requests                                                      | `nil`                                           |
-| `auth.defaultPermissions.subscribe`  | Default permission for subscribe requests                                                    | `nil`                                           |
-| `tls.enabled`                        | Enable TLS                                                                                   | `false`                                         |
-| `tls.serverSecret`                   | Certificates to secure the NATS client connections (type: kubernetes.io/tls)                 | `nil`                                           |
-| `tls.routesSecret`                   | Certificates to secure the routes. (type: kubernetes.io/tls)                                 | `nil`                                           |
-| `clusterSize`                        | Number of NATS nodes                                                                         | `3`                                             |
-| `clusterScoped`                      | Enable cluster scoped installation (read carefully the warnings)                             | `false`                                         |
-| `configReload.enabled`               | Enable configuration reload                                                                  | `false`                                         |
-| `configReload.registry`              | Reload configuration image registry                                                          | `docker.io`                                     |
-| `configReload.repository`            | Reload configuration image name                                                              | `connecteverything/nats-server-config-reloader` |
-| `configReload.tag`                   | Reload configuration image tag                                                               | `0.2.2-v1alpha2`                                |
-| `configReload.pullPolicy`            | Reload configuration image pull policy                                                       | `IfNotPresent`                                  |
-| `metrics.enabled`                    | Enable prometheus metrics exporter                                                           | `false`                                         |
-| `metrics.registry`                   | Prometheus metrics exporter image registry                                                   | `docker.io`                                     |
-| `metrics.repository`                 | Prometheus metrics exporter image name                                                       | `synadia/prometheus-nats-exporter`              |
-| `metrics.tag`                        | Prometheus metrics exporter image tag                                                        | `0.1.0`                                         |
-| `metrics.pullPolicy`                 | Prometheus metrics exporter image pull policy                                                | `IfNotPresent`                                  |
+| `rbacEnabled`                                | Switch to enable/disable RBAC for this chart                                                 | `true`                                          |
+| `clusterScoped`                              | Enable cluster scoped installation (read carefully the warnings)                             | `false`                                         |
+| `image.registry`                             | NATS Operator image registry                                                                 | `docker.io`                                     |
+| `image.repository`                           | NATS Operator image name                                                                     | `connecteverything/nats-operator`               |
+| `image.tag`                                  | NATS Operator image tag                                                                      | `0.4.3-v1alpha2`                                |
+| `image.pullPolicy`                           | Image pull policy                                                                            | `Always`                                        |
+| `image.pullSecrets`                          | Specify image pull secrets                                                                   | `nil`                                           |
+| `securityContext.enabled`                    | Enable security context                                                                      | `true`                                          |
+| `securityContext.fsGroup`                    | Group ID for the container                                                                   | `1001`                                          |
+| `securityContext.runAsUser`                  | User ID for the container                                                                    | `1001`                                          |
+| `nodeSelector`                               | Node labels for pod assignment                                                               | `nil`                                           |
+| `tolerations`                                | Toleration labels for pod assignment                                                         | `nil`                                           |
+| `schedulerName`                              | Name of an alternate scheduler                                                               | `nil`                                           |
+| `antiAffinity`                               | Anti-affinity for pod assignment (values: soft or hard)                                      | `soft`                                          |
+| `podAnnotations`                             | Annotations to be added to pods                                                              | `{}`                                            |
+| `podLabels`                                  | Additional labels to be added to pods                                                        | `{}`                                            |
+| `updateStrategy`                             | Replicaset Update strategy                                                                   | `OnDelete`                                      |
+| `rollingUpdatePartition`                     | Partition for Rolling Update strategy                                                        | `nil`                                           |
+| `resources`                                  | CPU/Memory resource requests/limits                                                          | `{}`                                            |
+| `livenessProbe.enabled`                      | Enable liveness probe                                                                        | `true`                                          |
+| `livenessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated                                                     | `30`                                            |
+| `livenessProbe.periodSeconds`                | How often to perform the probe                                                               | `10`                                            |
+| `livenessProbe.timeoutSeconds`               | When the probe times out                                                                     | `5`                                             |
+| `livenessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                             |
+| `livenessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                             |
+| `readinessProbe.enabled`                     | Enable readiness probe                                                                       | `true`                                          |
+| `readinessProbe.initialDelaySeconds`         | Delay before readiness probe is initiated                                                    | `5`                                             |
+| `readinessProbe.periodSeconds`               | How often to perform the probe                                                               | `10`                                            |
+| `readinessProbe.timeoutSeconds`              | When the probe times out                                                                     | `5`                                             |
+| `readinessProbe.failureThreshold`            | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                             |
+| `readinessProbe.successThreshold`            | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                             |
+| `cluster.create`                             | Create and deploy a NATS Cluster togheter with the operator                                  | `true`                                          |
+| `cluster.name`                               | Name of NATS Clust 																																					| `nats-cluster` 																	|
+| `cluster.namespadce`                         | Namepsace to deploy the NATS Cluster in, only possible if `clusterScoped` is set to `true`   | ``                                         |
+| `cluster.version`                            | Version of NATS Cluster                                                                      | `1.4.1`                                         |
+| `cluster.size`                               | Number of NATS Cluster nodes                                                                 | `3`                                             |
+| `cluster.auth.enabled`                       | Switch to enable/disable client authentication                                               | `true`                                          |
+| `cluster.auth.enableServiceAccounts`         | Enable ServiceAccounts permissions                                                           | `false`                                         |
+| `cluster.auth.username`                      | Client authentication username                                                               | `true`                                          |
+| `cluster.auth.password`                      | Client authentication password                                                               | `true`                                          |
+| `cluster.auth.users`                         | Allows multi-user authentication of 2 or more user                                           | `[]`                                            |
+| `cluster.auth.defaultPermissions`            | Enable default permissions for users                                                         | `{}`                                            |
+| `cluster.auth.defaultPermissions.publish`    | Default permission for publish requests                                                      | `nil`                                           |
+| `cluster.auth.defaultPermissions.subscribe`  | Default permission for subscribe requests                                                    | `nil`                                           |
+| `cluster.tls.enabled`                        | Enable TLS                                                                                   | `false`                                         |
+| `cluster.tls.serverSecret`                   | Certificates to secure the NATS client connections (type: kubernetes.io/tls)                 | `nil`                                           |
+| `cluster.tls.routesSecret`                   | Certificates to secure the routes. (type: kubernetes.io/tls)                                 | `nil`                                           |
+| `cluster.configReload.enabled`               | Enable configuration reload                                                                  | `false`                                         |
+| `cluster.configReload.registry`              | Reload configuration image registry                                                          | `docker.io`                                     |
+| `cluster.configReload.repository`            | Reload configuration image name                                                              | `connecteverything/nats-server-config-reloader` |
+| `cluster.configReload.tag`                   | Reload configuration image tag                                                               | `0.2.2-v1alpha2`                                |
+| `cluster.configReload.pullPolicy`            | Reload configuration image pull policy                                                       | `IfNotPresent`                                  |
+| `cluster.metrics.enabled`                    | Enable prometheus metrics exporter                                                           | `false`                                         |
+| `cluster.metrics.registry`                   | Prometheus metrics exporter image registry                                                   | `docker.io`                                     |
+| `cluster.metrics.repository`                 | Prometheus metrics exporter image name                                                       | `synadia/prometheus-nats-exporter`              |
+| `cluster.metrics.tag`                        | Prometheus metrics exporter image tag                                                        | `0.1.0`                                         |
+| `cluster.metrics.pullPolicy`                 | Prometheus metrics exporter image pull policy                                                | `IfNotPresent`                                  |
 
 ### Example
 
@@ -110,36 +123,37 @@ Here is an example of how to setup a NATS cluster with client authentication.
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 ```bash
-$ helm install --name my-release --set auth.enabled=true,auth.username=my-user,auth.password=T0pS3cr3t .
+$ helm install --name my-release --set cluster.auth.enabled=true,cluster.auth.username=my-user,cluster.auth.password=T0pS3cr3t .
 ```
 
 You can also specify more than 1 user using this way:
 
 ```bash
-helm install --name my-release --set auth.enabled=true,auth.users[0]=my-user,auth.users[0].password=T0pS3cr3t,auth.users[1]=my-user-2,auth.users[1].password=MyS3cr3tP4ssw0rd .
+$ helm install --name my-release --set cluster.auth.enabled=true,cluster.auth.users[0]=my-user,cluster.auth.users[0].password=T0pS3cr3t,cluster.auth.users[1]=my-user-2,cluster.auth.users[1].password=MyS3cr3tP4ssw0rd .
 ```
 You can consider editing the default values.yaml as it is easier to manage:
 
 ```yaml
 ...
-auth:
-  enabled: true
+cluster:
+  auth:
+    enabled: true
 
-  # username:
-  # password:
+    # username:
+    # password:
 
-  # values.yaml
-  users:
-    - username: "my-user"
-      password: "T0pS3cr3t"
-    - username: "my-user-2"
-      password: "MyS3cr3tP4ssw0rd"
+    # values.yaml
+    users:
+      - username: "my-user"
+        password: "T0pS3cr3t"
+      - username: "my-user-2"
+        password: "MyS3cr3tP4ssw0rd"
 ...
 ```
 
+Alternatively, a YAML file that specifies the values for the parameters can be
+provided while installing the chart. For example,
 
-
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 ```bash

--- a/helm/nats-operator/templates/natscluster.yaml
+++ b/helm/nats-operator/templates/natscluster.yaml
@@ -1,33 +1,38 @@
+{{- if .Values.cluster.create }}
 apiVersion: "nats.io/v1alpha2"
 kind: "NatsCluster"
 metadata:
-  name: "nats-cluster"
+  name: {{ .Values.cluster.name }}
+{{- if and .Values.clusterScoped .Values.cluster.namespace }}
+  namespace: {{ .Values.cluster.namespace }}
+{{- end }}
 spec:
-  size: {{ .Values.clusterSize }}
-  version: {{ .Values.natsClusterVersion }}
+  size: {{ .Values.cluster.size }}
+  version: {{ .Values.cluster.version }}
 
   pod:
-    enableConfigReload: {{ .Values.configReload.enabled }}
-    reloaderImage: {{ .Values.configReload.repository }}
-    reloaderImageTag: {{ .Values.configReload.tag }}
-    reloaderImagePullPolicy: {{ .Values.configReload.pullPolicy }}
+    enableConfigReload: {{ .Values.cluster.configReload.enabled }}
+    reloaderImage: {{ .Values.cluster.configReload.repository }}
+    reloaderImageTag: {{ .Values.cluster.configReload.tag }}
+    reloaderImagePullPolicy: {{ .Values.cluster.configReload.pullPolicy }}
 
-    enableMetrics: {{ .Values.metrics.enabled }}
-    metricsImage: {{ .Values.metrics.repository }}
-    metricsImageTag: {{ .Values.metrics.tag }}
-    metricsImagePullPolicy: {{ .Values.metrics.pullPolicy }}
-  {{- if .Values.auth.enabled }}
+    enableMetrics: {{ .Values.cluster.metrics.enabled }}
+    metricsImage: {{ .Values.cluster.metrics.repository }}
+    metricsImageTag: {{ .Values.cluster.metrics.tag }}
+    metricsImagePullPolicy: {{ .Values.cluster.metrics.pullPolicy }}
+  {{- if .Values.cluster.auth.enabled }}
   auth:
-    enableServiceAccounts: {{ .Values.auth.enableServiceAccounts }}
-    clientsAuthSecret: {{ template "nats.fullname" . }}-clients-auth
+    enableServiceAccounts: {{ .Values.cluster.auth.enableServiceAccounts }}
+    clientsAuthSecret: {{ .Values.cluster.name }}-clients-auth
     clientsAuthTimeout: 5
   {{- end }}
 
-  {{- if .Values.tls.enabled }}
+  {{- if .Values.cluster.tls.enabled }}
   tls:
     # Certificates to secure the NATS client connections:
-    serverSecret: {{ .Values.tls.serverSecret }}
+    serverSecret: {{ .Values.cluster.tls.serverSecret }}
 
     # Certificates to secure the routes.
-    routesSecret: {{ .Values.tls.routesSecret }}
+    routesSecret: {{ .Values.cluster.tls.routesSecret }}
   {{- end }}
+{{- end }}

--- a/helm/nats-operator/templates/secret.yaml
+++ b/helm/nats-operator/templates/secret.yaml
@@ -1,14 +1,11 @@
-{{- if .Values.auth.enabled }}
+{{- if and .Values.cluster.create .Values.cluster.auth.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "nats.fullname" . }}-clients-auth
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: "{{ template "nats.name" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  name: {{ .Values.cluster.name }}-clients-auth
+{{- if and .Values.clusterScoped .Values.cluster.namespace }}
+  namespace: {{ .Values.cluster.namespace }}
+{{- end }}
 type: Opaque
 data:
   clients-auth.json: {{ (tpl (.Files.Get "config/client-auth.json") . ) | b64enc }}

--- a/helm/nats-operator/values.yaml
+++ b/helm/nats-operator/values.yaml
@@ -3,8 +3,11 @@
 ##
 rbacEnabled: true
 
-# Nats version. Image tags are listed here: https://hub.docker.com/_/nats?tab=tags
-natsClusterVersion: 1.4.1
+## Operator scope
+## NOTE: If true
+## * Make sure that no othe NATS operator is running in the cluster
+## * The Release namespace must be "nats-io"
+clusterScoped: false
 
 image:
 # connecteverything/nats-operator:0.2.3-v1alpha2
@@ -95,61 +98,69 @@ readinessProbe:
   failureThreshold: 6
   successThreshold: 1
 
-## Client Authentication
-## ref: https://github.com/nats-io/gnatsd#authentication
-## note: token not supported only user/password will work with this chart version 
-##
-auth:
-  enabled: true
+cluster:
+  ## Create a NATS Cluster when installing the operator
+  create: true
 
-  # NOTE: Only supported in Kubernetes v1.12+ clusters having the "TokenRequest" API enabled.
-  enableServiceAccounts: false
-  
-  ## This is where you enter a username/password for 1 user
-  username: "my-user"
-  password: "T0pS3cr3t"
+  name: nats-cluster
 
-  ## This is a where you can specify 2 or more users
-  users: {}
-  #- username: "another-user-1"
-  #  password: "another-password-1"
-  #- username: "another-user-2"
-  #  password: "another-password-2"
-  #  permissions:
-  #    publish: ["hello.*"]
-  #    subscribe: ["hello.world"]
+  ## Choose namespace for cluster deployment if clusterScoped is set to true
+  # namesapce: "some-namespace"
 
-  defaultPermissions: {}
-    #publish: ["SANDBOX.*"]
-    #subscribe: ["PUBLIC.>"]
+  ## Nats version
+  ## Image tags are listed here: https://hub.docker.com/_/nats?tab=tags
+  version: 1.4.1
 
-tls:
-  enabled: false
-  #serverSecret:
-  #routesSecret:
+  ## Cluster Size
+  size: 3
 
-clusterSize: 3
+  ## Client Authentication
+  ## ref: https://github.com/nats-io/gnatsd#authentication
+  ## note: token not supported only user/password will work with this chart version
+  ##
+  auth:
+    enabled: true
 
-## Operator scope
-## NOTE: If true
-## * Make sure that no othe NATS operator is running in the cluster
-## * The Release namespace must be "nats-io"
-clusterScoped: false
+    # NOTE: Only supported in Kubernetes v1.12+ clusters having the "TokenRequest" API enabled.
+    enableServiceAccounts: false
 
-## Configuration Reload
-## NOTE: Only supported in Kubernetes v1.12+.
-configReload:
-  enabled: false
-  registry: "docker.io"
-  repository: "connecteverything/nats-server-config-reloader"
-  tag: "0.2.2-v1alpha2"
-  pullPolicy: "IfNotPresent"
+    ## This is where you enter a username/password for 1 user
+    username: "my-user"
+    password: "T0pS3cr3t"
 
-## Prometheus Metrics Exporter
-##
-metrics:
-  enabled: false
-  registry: "docker.io"
-  repository: "synadia/prometheus-nats-exporter"
-  tag: "0.2.0"
-  pullPolicy: "IfNotPresent"
+    ## This is a where you can specify 2 or more users
+    users: []
+    #- username: "another-user-1"
+    #  password: "another-password-1"
+    #- username: "another-user-2"
+    #  password: "another-password-2"
+    #  permissions:
+    #    publish: ["hello.*"]
+    #    subscribe: ["hello.world"]
+
+    defaultPermissions: {}
+      #publish: ["SANDBOX.*"]
+      #subscribe: ["PUBLIC.>"]
+
+  tls:
+    enabled: false
+    #serverSecret:
+    #routesSecret:
+
+  ## Configuration Reload
+  ## NOTE: Only supported in Kubernetes v1.12+.
+  configReload:
+    enabled: false
+    registry: "docker.io"
+    repository: "connecteverything/nats-server-config-reloader"
+    tag: "0.2.2-v1alpha2"
+    pullPolicy: "IfNotPresent"
+
+  ## Prometheus Metrics Exporter
+  ##
+  metrics:
+    enabled: false
+    registry: "docker.io"
+    repository: "synadia/prometheus-nats-exporter"
+    tag: "0.2.0"
+    pullPolicy: "IfNotPresent"


### PR DESCRIPTION
This pull request refactors the Helm Chart and makes it possible to customize the NatsCluster

* Moved all NatsCluster configuration under a `cluster.*` object in values.yaml
* Added possibility to customzie the name and namespace of the deployed NATS Cluster. This is handy if `clusterScope` is set to `true` and you want to deploy the NatsCluster in the same namespace as your applications.

A complete example could look something like this `my-values.yaml`:

```yaml
clusterScoped: true

cluster:
  create: true
  name: my-nats-cluster
  namespace: my-namespace
  size: 3

  auth:
    enabled: true
    enableServiceAccounts: true

    username: false
    users: []

  configReload:
    enabled: true

  metrics:
    enabled: true
```

Which is deployed like this:

```bash
$ helm install --wait -f my-values.yaml --namespace nats-io --name my-nats-operator .
```