### PR TITLE
Fix helm chart labels and auth config

### DIFF
--- a/helm/nats-operator/Chart.yaml
+++ b/helm/nats-operator/Chart.yaml
@@ -1,6 +1,6 @@
 name: nats-operator
-version: 0.1.0
-appVersion: 0.2.3
+version: 0.1.1
+appVersion: 0.4.4
 description: Nats operator creates/configures/manages nats clusters atop Kubernetes
 keywords:
 - addressing

--- a/helm/nats-operator/config/client-auth.json
+++ b/helm/nats-operator/config/client-auth.json
@@ -1,16 +1,16 @@
 {
   "users": [
-    {{- if and (.Values.auth.username) (not .Values.auth.users) }}
-    { 
-      "username": "{{ .Values.auth.username }}",
-      "password": "{{ .Values.auth.password }}"
+    {{- if and (.Values.cluster.auth.username) (not .Values.cluster.auth.users) }}
+    {
+      "username": "{{ .Values.cluster.auth.username }}",
+      "password": "{{ .Values.cluster.auth.password }}"
     }
     {{- end }}
-   
-    {{- if .Values.auth.users }}
-    {{ $length := len .Values.auth.users }}
-    {{- range $index, $user := .Values.auth.users }}
-    { 
+
+    {{- if .Values.cluster.auth.users }}
+    {{ $length := len .Values.cluster.auth.users }}
+    {{- range $index, $user := .Values.cluster.auth.users }}
+    {
       "username": "{{ $user.username }}",
       "password": "{{ $user.password }}"
       {{- if $user.permissions }},
@@ -19,7 +19,7 @@
     }{{- if lt (add1 $index) $length }},{{ end }}
     {{- end}}
     {{- end }}
-  ]{{- if .Values.auth.defaultPermissions }},
-  "default_permissions": {{ toJson .Values.auth.defaultPermissions | replace "\\u003e" ">" }}
+  ]{{- if .Values.cluster.auth.defaultPermissions }},
+  "default_permissions": {{ toJson .Values.cluster.auth.defaultPermissions | replace "\\u003e" ">" }}
   {{- end}}
 }

--- a/helm/nats-operator/templates/deployment.yaml
+++ b/helm/nats-operator/templates/deployment.yaml
@@ -2,20 +2,22 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "nats.fullname" . }}
+  labels:
+    app: {{ template "nats.name" . }}
+    chart: {{ template "nats.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: "{{ template "nats.name" . }}"
-      chart: "{{ template "nats.chart" . }}"
-      release: "{{ .Release.Name }}"
+      app: {{ template "nats.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: "{{ template "nats.name" . }}"
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
-        heritage: "{{ .Release.Service }}"
+        app: {{ template "nats.name" . }}
+        release: {{ .Release.Name }}
       {{- if .Values.podLabels }}
         {{ .Values.podLabels}}
       {{- end }}

--- a/helm/nats-operator/values.yaml
+++ b/helm/nats-operator/values.yaml
@@ -13,7 +13,7 @@ image:
 # connecteverything/nats-operator:0.2.3-v1alpha2
   registry: docker.io
   repository: connecteverything/nats-operator
-  tag: 0.4.3-v1alpha2
+  tag: 0.4.4-v1alpha2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Just upgraded to the new chart and found that due to the current label usage the NATS Operator deployment could not be upgraded becuase it contains the Chart Version in `matchLabels` and `matchLabels` are immutable and can not be changed without first deleting the deployment.

This makes it possible to upgrade the chart version without getting errors about the deployment from Kuberntes.

This pull request also fixes an error where the auth config was not upgraded when the new values was changed as well as bumping the version to the latest version of the NATS Operator.