### PR TITLE
Added options to overwrite default ca, key and cert names in TLS secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,21 @@ spec:
   tls:
     # Certificates to secure the NATS client connections:
     serverSecret: "nats-clients-tls"
+    # Name of the CA in nats-clients-tls
+    serverSecretCAFileName: "ca.pem"
+    # Name of the key in nats-clients-tls
+    serverSecretKeyFileName: "server-key.pem"
+    # Name of the certificate in nats-clients-tls
+    serverSecretCertFileName: "server.pem"
 
     # Certificates to secure the routes.
     routesSecret: "nats-routes-tls"
+    # Name of the CA in nats-routes-tls
+    routesSecretCAFileName: "ca.pem"
+    # Name of the key in nats-routes-tls
+    routesSecretKeyFileName: "route-key.pem"
+    # Name of the certificate in nats-routes-tls
+    routesSecretCertFileName: "route.pem"
 ```
 
 In order for TLS to be properly established between the nodes, it is 

--- a/example/example-nats-cluster-tls.yaml
+++ b/example/example-nats-cluster-tls.yaml
@@ -13,6 +13,18 @@ spec:
   tls:
     # Certificates to secure the NATS client connections:
     serverSecret: "nats-clients-tls"
+    # Name of the CA in nats-clients-tls
+    serverSecretCAFileName: "ca.pem"
+    # Name of the key in nats-clients-tls
+    serverSecretKeyFileName: "server-key.pem"
+    # Name of the certificate in nats-clients-tls
+    serverSecretCertFileName: "server.pem"
 
     # Certificates to secure the routes.
     routesSecret: "nats-routes-tls"
+    # Name of the CA in nats-routes-tls
+    routesSecretCAFileName: "ca.pem"
+    # Name of the key in nats-routes-tls
+    routesSecretKeyFileName: "route-key.pem"
+    # Name of the certificate in nats-routes-tls
+    routesSecretCertFileName: "route.pem"

--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -159,9 +159,33 @@ type TLSConfig struct {
 	// to secure the port to which the clients connect.
 	ServerSecret string `json:"serverSecret,omitempty"`
 
+	// ServerSecretCAFileName is the name of the CA in ServerSecret
+	// (default: ca.pem)
+	ServerSecretCAFileName string `json:"serverSecretCAFileName,omitempty"`
+
+	// ServerSecretKeyFileName is the name of the key in ServerSecret
+	// (default: server-key.pem)
+	ServerSecretKeyFileName string `json:"serverSecretKeyFileName,omitempty"`
+
+	// ServerSecretCertFileName is the name of the certificate in ServerSecret
+	// (default: server.pem)
+	ServerSecretCertFileName string `json:"serverSecretCertFileName,omitempty"`
+
 	// RoutesSecret is the secret containing the certificates
 	// to secure the port to which cluster routes connect.
 	RoutesSecret string `json:"routesSecret,omitempty"`
+
+	// RoutesSecretCAFileName is the name of the CA in RoutesSecret
+	// (default: ca.pem)
+	RoutesSecretCAFileName string `json:"routesSecretCAFileName,omitempty"`
+
+	// RoutesSecretKeyFileName is the name of the key in RoutesSecret
+	// (default: route-key.pem)
+	RoutesSecretKeyFileName string `json:"routesSecretKeyFileName,omitempty"`
+
+	// RoutesSecretCertFileName is the name of the certificate in RoutesSecret
+	// (default: route.pem)
+	RoutesSecretCertFileName string `json:"routesSecretCertFileName,omitempty"`
 
 	// EnableHttps makes the monitoring endpoint use https.
 	EnableHttps bool `json:"enableHttps,omitempty"`
@@ -293,6 +317,27 @@ func (c *ClusterSpec) Cleanup() {
 	}
 
 	c.Version = strings.TrimLeft(c.Version, "v")
+
+	if c.TLS != nil {
+		if len(c.TLS.ServerSecretCAFileName) == 0 {
+			c.TLS.ServerSecretCAFileName = constants.DefaultServerCAFileName
+		}
+		if len(c.TLS.ServerSecretCertFileName) == 0 {
+			c.TLS.ServerSecretCertFileName = constants.DefaultServerCertFileName
+		}
+		if len(c.TLS.ServerSecretKeyFileName) == 0 {
+			c.TLS.ServerSecretKeyFileName = constants.DefaultServerKeyFileName
+		}
+		if len(c.TLS.RoutesSecretCAFileName) == 0 {
+			c.TLS.RoutesSecretCAFileName = constants.DefaultRoutesCAFileName
+		}
+		if len(c.TLS.RoutesSecretCertFileName) == 0 {
+			c.TLS.RoutesSecretCertFileName = constants.DefaultRoutesCertFileName
+		}
+		if len(c.TLS.RoutesSecretKeyFileName) == 0 {
+			c.TLS.RoutesSecretKeyFileName = constants.DefaultRoutesKeyFileName
+		}
+	}
 }
 
 type ClusterPhase string

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -68,20 +68,20 @@ const (
 
 	// ServerCertsMountPath is the path where the server certificates
 	// to secure clients connections are located.
-	ServerCertsMountPath = "/etc/nats-server-tls-certs"
-	ServerCAFilePath     = ServerCertsMountPath + "/ca.pem"
-	ServerCertFilePath   = ServerCertsMountPath + "/server.pem"
-	ServerKeyFilePath    = ServerCertsMountPath + "/server-key.pem"
+	ServerCertsMountPath      = "/etc/nats-server-tls-certs"
+	DefaultServerCAFileName   = "ca.pem"
+	DefaultServerCertFileName = "server.pem"
+	DefaultServerKeyFileName  = "server-key.pem"
 
 	// RoutesSecretVolumeName is the name of the volume used for the routes certs.
 	RoutesSecretVolumeName = "routes-tls-certs"
 
 	// RoutesCertsMountPath is the path where the certificates
 	// to secure routes connections are located.
-	RoutesCertsMountPath = "/etc/nats-routes-tls-certs"
-	RoutesCAFilePath     = RoutesCertsMountPath + "/ca.pem"
-	RoutesCertFilePath   = RoutesCertsMountPath + "/route.pem"
-	RoutesKeyFilePath    = RoutesCertsMountPath + "/route-key.pem"
+	RoutesCertsMountPath      = "/etc/nats-routes-tls-certs"
+	DefaultRoutesCAFileName   = "ca.pem"
+	DefaultRoutesCertFileName = "route.pem"
+	DefaultRoutesKeyFileName  = "route-key.pem"
 
 	// Default Docker Images
 	DefaultServerImage             = "nats"

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -156,9 +156,9 @@ func addTLSConfig(sconfig *natsconf.ServerConfig, cs v1alpha2.ClusterSpec) {
 
 	if cs.TLS.ServerSecret != "" {
 		sconfig.TLS = &natsconf.TLSConfig{
-			CAFile:   constants.ServerCAFilePath,
-			CertFile: constants.ServerCertFilePath,
-			KeyFile:  constants.ServerKeyFilePath,
+			CAFile:   constants.ServerCertsMountPath + "/" + cs.TLS.ServerSecretCAFileName,
+			CertFile: constants.ServerCertsMountPath + "/" + cs.TLS.ServerSecretCertFileName,
+			KeyFile:  constants.ServerCertsMountPath + "/" + cs.TLS.ServerSecretKeyFileName,
 		}
 
 		if cs.TLS.ClientsTLSTimeout > 0 {
@@ -167,9 +167,9 @@ func addTLSConfig(sconfig *natsconf.ServerConfig, cs v1alpha2.ClusterSpec) {
 	}
 	if cs.TLS.RoutesSecret != "" {
 		sconfig.Cluster.TLS = &natsconf.TLSConfig{
-			CAFile:   constants.RoutesCAFilePath,
-			CertFile: constants.RoutesCertFilePath,
-			KeyFile:  constants.RoutesKeyFilePath,
+			CAFile:   constants.RoutesCertsMountPath + "/" + cs.TLS.RoutesSecretCAFileName,
+			CertFile: constants.RoutesCertsMountPath + "/" + cs.TLS.RoutesSecretCertFileName,
+			KeyFile:  constants.RoutesCertsMountPath + "/" + cs.TLS.RoutesSecretKeyFileName,
 		}
 		if cs.TLS.RoutesTLSTimeout > 0 {
 			sconfig.Cluster.TLS.Timeout = cs.TLS.RoutesTLSTimeout


### PR DESCRIPTION
New options:
```
tls:
    serverSecretCAFileName: ca.crt
    serverSecretCertFileName: tls.crt
    serverSecretKeyFileName: tls.key
    routesSecretCAFileName: ca.crt
    routesSecretCertFileName: tls.crt
    routesSecretKeyFileName: tls.key
```

Use case: kubernetes.io/tls secrets (e.g.: cert-manager-managed certificates)