### PR TITLE
Add Prometheus ServiceMonitor for Helm Chart Cluster deployment

### DIFF
--- a/helm/nats-operator/Chart.yaml
+++ b/helm/nats-operator/Chart.yaml
@@ -1,5 +1,5 @@
 name: nats-operator
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.4.4
 description: Nats operator creates/configures/manages nats clusters atop Kubernetes
 keywords:

--- a/helm/nats-operator/templates/natscluster.yaml
+++ b/helm/nats-operator/templates/natscluster.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.cluster.create }}
 apiVersion: "nats.io/v1alpha2"
 kind: "NatsCluster"
@@ -35,4 +36,27 @@ spec:
     # Certificates to secure the routes.
     routesSecret: {{ .Values.cluster.tls.routesSecret }}
   {{- end }}
+---
+{{- if and .Values.cluster.metrics.enabled .Values.cluster.metrics.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.cluster.name }}
+{{- if and .Values.clusterScoped .Values.cluster.namespace }}
+  namespace: {{ .Values.cluster.namespace }}
+{{- end }}
+  labels:
+    app: nats
+    nats_cluster: {{ .Values.cluster.name }}
+    prometheus: {{ .Values.cluster.metrics.servicemonitor.prometheusInstance }}
+spec:
+  jobLabel: nats-{{ .Values.cluster.name }}
+  selector:
+    matchLabels:
+      app: nats
+      nats_cluster: {{ .Values.cluster.name }}
+  endpoints:
+  - port: metrics
+    interval: 60s
+{{- end }}
 {{- end }}

--- a/helm/nats-operator/values.yaml
+++ b/helm/nats-operator/values.yaml
@@ -164,3 +164,9 @@ cluster:
     repository: "synadia/prometheus-nats-exporter"
     tag: "0.2.0"
     pullPolicy: "IfNotPresent"
+
+    # Prometheus Operator ServiceMonitor config
+    ##
+    servicemonitor:
+      enabled: false
+      prometheusInstance: default


### PR DESCRIPTION
The classic way of monitoring pods with Prometheus is with scrape annotations. The Prometheus Operator which is becoming more and more popular way of deploying Prometheus has moved away from annotations to a custom object called a [`ServiceMonitor`][servicemonitor].

This Pull Request adds an optional `ServiceMonitor` for the deployed cluster. This can be removed if the operator creates this by itself as per feature request #176.

[servicemonitor]: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/running-exporters.md