### PR TITLE
Enable specifing a `ClientsAuthFile` for user authorization data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ e2e: NAMESPACE ?= default
 e2e:
 	FEATURE_GATE_CLUSTER_SCOPED=$(FEATURE_GATE_CLUSTER_SCOPED) MODE=run NAMESPACE=$(NAMESPACE) PROFILE=local TARGET=operator $(MAKE) run
 	FEATURE_GATE_CLUSTER_SCOPED=$(FEATURE_GATE_CLUSTER_SCOPED) MODE=run NAMESPACE=$(NAMESPACE) PROFILE=local TARGET=e2e $(MAKE) run
-	@go test -tags e2e -v ./test/e2e/main_test.go -feature-gates=ClusterScoped=$(FEATURE_GATE_CLUSTER_SCOPED) -kubeconfig $(KUBECONFIG) -namespace $(NAMESPACE) -wait
+	@go test -timeout 20m -tags e2e -v ./test/e2e/main_test.go -feature-gates=ClusterScoped=$(FEATURE_GATE_CLUSTER_SCOPED) -kubeconfig $(KUBECONFIG) -namespace $(NAMESPACE) -wait
 
 # run deploys either nats-operator or nats-operator-e2e to the Kubernetes cluster targeted by the current kubeconfig.
 .PHONY: run

--- a/example/example-nats-cluster-authfile.yaml
+++ b/example/example-nats-cluster-authfile.yaml
@@ -1,35 +1,40 @@
 # This is an example NatsCluster manifest which uses a 3rd party initContainer
 # to fetch the authorization credentials from outside kubernetes.
 #
-# An example of this could be consul-template getting user/passwords from vault.
 apiVersion: "nats.io/v1alpha2"
 kind: "NatsCluster"
 metadata:
-  name: my-nats-cluster
-  namespace: nats-stuff
+  name: nats-auth-file-example
+  namespace: default
 spec:
-  size: 5
-  version: "1.3.0"
-  service:
+  size: 1
+  version: "1.4.1"
+
+  natsConfig:
     maxPayload: 20971520
+
   pod:
+    enableConfigReload: true
+
     volumeMounts:
       - name: authconfig
         mountPath: /etc/nats-config/authconfig
-  template:
-    serviceAccountName: my-secrets-getting-sa
-    initContainers:
-      - name: secret-getter
-        image: "busybox"
-        command: ["sh", "-c", "echo 'users = [ { user: 'foo', pass: 'bar' } ]' > /etc/nats-config/authconfig/auth.json"]
-        volumeMounts:
-          - name: authconfig
-            mountPath: /etc/nats-config/authconfig
-    volumes:
-      - name: authconfig
-        emptyDir: {}
+
   auth:
     # Needs to be under /etc/nats-config where nats looks
     # for its config file, or it won't be able to be included
     # by /etc/nats-config/gnatsd.conf
-    clientAuthFile: "authconfig/auth.json"
+    clientsAuthFile: "authconfig/auth.json"
+
+  template:
+    spec:
+      initContainers:
+        - name: secret-getter
+          image: "busybox"
+          command: ["sh", "-c", "echo 'users = [ { user: 'foo', pass: 'bar' } ]' > /etc/nats-config/authconfig/auth.json"]
+          volumeMounts:
+            - name: authconfig
+              mountPath: /etc/nats-config/authconfig
+      volumes:
+        - name: authconfig
+          emptyDir: {}

--- a/example/example-nats-cluster-authfile.yaml
+++ b/example/example-nats-cluster-authfile.yaml
@@ -1,0 +1,35 @@
+# This is an example NatsCluster manifest which uses a 3rd party initContainer
+# to fetch the authorization credentials from outside kubernetes.
+#
+# An example of this could be consul-template getting user/passwords from vault.
+apiVersion: "nats.io/v1alpha2"
+kind: "NatsCluster"
+metadata:
+  name: my-nats-cluster
+  namespace: nats-stuff
+spec:
+  size: 5
+  version: "1.3.0"
+  service:
+    maxPayload: 20971520
+  pod:
+    volumeMounts:
+      - name: authconfig
+        mountPath: /etc/nats-config/authconfig
+  template:
+    serviceAccountName: my-secrets-getting-sa
+    initContainers:
+      - name: secret-getter
+        image: "busybox"
+        command: ["sh", "-c", "echo 'users = [ { user: 'foo', pass: 'bar' } ]' > /etc/nats-config/authconfig/auth.json"]
+        volumeMounts:
+          - name: authconfig
+            mountPath: /etc/nats-config/authconfig
+    volumes:
+      - name: authconfig
+        emptyDir: {}
+  auth:
+    # Needs to be under /etc/nats-config where nats looks
+    # for its config file, or it won't be able to be included
+    # by /etc/nats-config/gnatsd.conf
+    clientAuthFile: "authconfig/auth.json"

--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -287,6 +287,10 @@ type AuthConfig struct {
 	// configuration in JSON.
 	ClientsAuthSecret string `json:"clientsAuthSecret,omitempty"`
 
+	// ClientsAuthFile is the path that nats-operator should read
+	// auth secrets from on disk.
+	ClientsAuthFile string `json:"clientsAuthFile,omitempty"`
+
 	// ClientsAuthTimeout is the time in seconds that the NATS server will
 	// allow to clients to send their auth credentials.
 	ClientsAuthTimeout int `json:"clientsAuthTimeout,omitempty"`

--- a/pkg/conf/natsconf.go
+++ b/pkg/conf/natsconf.go
@@ -52,6 +52,7 @@ type AuthorizationConfig struct {
 	Timeout            int          `json:"timeout,omitempty"`
 	Users              []*User      `json:"users,omitempty"`
 	DefaultPermissions *Permissions `json:"default_permissions,omitempty"`
+	Include            string       `json:"include,omitempty"`
 }
 
 type User struct {

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -321,6 +321,11 @@ func addAuthConfig(
 			break
 		}
 		return nil
+	} else if cs.Auth.ClientsAuthFile != "" {
+		sconfig.Authorization = &natsconf.AuthorizationConfig{
+			Include: cs.Auth.ClientsAuthFile,
+		}
+		return nil
 	}
 	return nil
 }
@@ -427,9 +432,7 @@ func CreateConfigSecret(kubecli corev1client.CoreV1Interface, operatorcli natsal
 
 	// FIXME: Quoted "include" causes include to be ignored.
 	// Remove once using NATS v2.0 as the default container image.
-	if cluster.Pod != nil && cluster.Pod.AdvertiseExternalIP {
-		rawConfig = bytes.Replace(rawConfig, []byte(`"include":`), []byte("include "), 1)
-	}
+	rawConfig = bytes.Replace(rawConfig, []byte(`"include":`), []byte("include "), -1)
 
 	labels := LabelsForCluster(clusterName)
 	cm := &v1.Secret{
@@ -840,7 +843,12 @@ func NewNatsPodSpec(namespace, name, clusterName string, cs v1alpha2.ClusterSpec
 			imagePullPolicy = cs.Pod.ReloaderImagePullPolicy
 		}
 
-		reloaderContainer := natsPodReloaderContainer(image, imageTag, imagePullPolicy)
+		authFilePath := ""
+		if cs.Auth != nil {
+			authFilePath = cs.Auth.ClientsAuthFile
+		}
+
+		reloaderContainer := natsPodReloaderContainer(image, imageTag, imagePullPolicy, authFilePath)
 		reloaderContainer.VolumeMounts = volumeMounts
 		containers = append(containers, reloaderContainer)
 	}

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -431,7 +431,6 @@ func CreateConfigSecret(kubecli corev1client.CoreV1Interface, operatorcli natsal
 	}
 
 	// FIXME: Quoted "include" causes include to be ignored.
-	// Remove once using NATS v2.0 as the default container image.
 	rawConfig = bytes.Replace(rawConfig, []byte(`"include":`), []byte("include "), -1)
 
 	labels := LabelsForCluster(clusterName)
@@ -539,10 +538,7 @@ func UpdateConfigSecret(
 	}
 
 	// FIXME: Quoted "include" causes include to be ignored.
-	// Remove once using NATS v2.0 as the default container image.
-	if cluster.Pod != nil && cluster.Pod.AdvertiseExternalIP {
-		rawConfig = bytes.Replace(rawConfig, []byte(`"include":`), []byte("include "), 1)
-	}
+	rawConfig = bytes.Replace(rawConfig, []byte(`"include":`), []byte("include "), -1)
 
 	cm, err := kubecli.Secrets(ns).Get(clusterName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -94,7 +95,9 @@ func natsPodReloaderContainer(image, tag, pullPolicy, authFilePath string) v1.Co
 		},
 	}
 	if authFilePath != "" {
-		container.Command = append(container.Command, "-config", authFilePath)
+		// The volume is mounted as a subdirectory under the NATS config.
+		af := filepath.Join(constants.ConfigMapMountPath, authFilePath)
+		container.Command = append(container.Command, "-config", af)
 	}
 	return container
 }

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -80,8 +80,8 @@ func natsPodContainer(clusterName, version string, serverImage string, enableCli
 }
 
 // natsPodReloaderContainer returns a NATS server pod container spec for configuration reloader.
-func natsPodReloaderContainer(image, tag, pullPolicy string) v1.Container {
-	return v1.Container{
+func natsPodReloaderContainer(image, tag, pullPolicy, authFilePath string) v1.Container {
+	container := v1.Container{
 		Name:            "reloader",
 		Image:           fmt.Sprintf("%s:%s", image, tag),
 		ImagePullPolicy: v1.PullPolicy(pullPolicy),
@@ -93,6 +93,10 @@ func natsPodReloaderContainer(image, tag, pullPolicy string) v1.Container {
 			constants.PidFilePath,
 		},
 	}
+	if authFilePath != "" {
+		container.Command = append(container.Command, "-config", authFilePath)
+	}
+	return container
 }
 
 // natsPodMetricsContainer returns a NATS server pod container spec for prometheus metrics exporter.

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -23,12 +23,14 @@ import (
 	natsv1alpha2 "github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
 )
 
-// TestUpgradeCluster creates a NatsCluster resource with version 1.2.0 and waits for the full mesh to be formed.
-// Then, it updates the ".spec.version" field of the NatsCluster resource to 1.3.0 and waits for the upgrade to be performed.
+// TestUpgradeCluster creates a NatsCluster resource with version
+// 1.3.0 and waits for the full mesh to be formed.  Then, it updates
+// the ".spec.version" field of the NatsCluster resource to 1.4.0 and
+// waits for the upgrade to be performed.
 func TestUpgradeCluster(t *testing.T) {
 	var (
-		initialVersion = "1.2.0"
-		finalVersion   = "1.3.0"
+		initialVersion = "1.3.0"
+		finalVersion   = "1.4.0"
 		size           = 2
 	)
 
@@ -55,7 +57,6 @@ func TestUpgradeCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Upgrade the cluster's version to 1.3.0.
 	natsCluster.Spec.Version = finalVersion
 	if natsCluster, err = f.PatchCluster(natsCluster); err != nil {
 		t.Fatal(err)

--- a/test/reloader/reloader_test.go
+++ b/test/reloader/reloader_test.go
@@ -97,7 +97,9 @@ func TestReloader(t *testing.T) {
 		t.Fatal(err)
 	}
 	// We should have gotten only one signal for each configuration file
-	if signals != len(configFiles) {
-		t.Fatalf("Wrong number of signals received.")
+	got := signals
+	expected := len(configFiles)
+	if got != expected {
+		t.Fatalf("Wrong number of signals received. Expected: %v, got: %v", expected, got)
 	}
 }


### PR DESCRIPTION
Follow up from https://github.com/nats-io/nats-operator/pull/159 
Includes a few fixes and also extends the tests timeout to 20m since with the tests added in this branch now `go test` takes over 10m which makes the test build fail. /cc @schancel 