### PR TITLE
Add support to toggle TLS certs verify for clients

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -197,6 +197,9 @@ type TLSConfig struct {
 	// RoutesTLSTimeout is the time in seconds that the NATS server will
 	// allow to routes to finish the TLS handshake.
 	RoutesTLSTimeout float64 `json:"routesTLSTimeout,omitempty"`
+
+	// Verify toggles verifying TLS certs for clients.
+	Verify bool `json:"verify,omitempty"`
 }
 
 // PodPolicy defines the policy to create pod for the NATS container.

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -164,6 +164,9 @@ func addTLSConfig(sconfig *natsconf.ServerConfig, cs v1alpha2.ClusterSpec) {
 		if cs.TLS.ClientsTLSTimeout > 0 {
 			sconfig.TLS.Timeout = cs.TLS.ClientsTLSTimeout
 		}
+
+		// Verifying clients cert is disabled by default.
+		sconfig.TLS.Verify = cs.TLS.Verify
 	}
 	if cs.TLS.RoutesSecret != "" {
 		sconfig.Cluster.TLS = &natsconf.TLSConfig{

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	OperatorVersion = "0.4.4-v1alpha2+git"
+	OperatorVersion = "0.4.5-v1alpha2+git"
 	GitSHA          = "Not provided"
 )


### PR DESCRIPTION
Example: 

```yaml
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "nats"
spec:
  # Number of nodes in the cluster
  size: 1
  serverImage: "synadia/nats-server"
  version: "edge-v2.0.0-RC11"

  tls:
    verify: true
    serverSecret: "nats-certs"
```

Result: 
```js
{
  "port": 4222,
  "http_port": 8222,
  "cluster": {
    "port": 6222,
    "routes": [
      "nats://nats-1.nats-mgmt.default.svc:6222"
    ]
  },
  "tls": {
    "ca_file": "/etc/nats-server-tls-certs/ca.pem",
    "cert_file": "/etc/nats-server-tls-certs/server.pem",
    "key_file": "/etc/nats-server-tls-certs/server-key.pem",
    "verify": true
  },
  "logtime": true
}
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>