### PR TITLE
Add docs related to nats.io crd

### DIFF
--- a/helm/nats-operator/README.md
+++ b/helm/nats-operator/README.md
@@ -40,12 +40,24 @@ parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
+> **Tip**: If you want to RE-INSTALL the NATS Operator, please ensure you deleted `*.nats.io` custom resource definitions
+> ```shell 
+> $ kubectl delete crd/natsserviceroles.nats.io
+> $ kubectl delete crd/natsclusters.nats.io   
+> ```
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:
 
 ```bash
-$ helm delete my-release
+# Delete Helm release
+$ helm delete my-release --purge
+
+# Delete CRDs
+$ kubectl delete crd/natsserviceroles.nats.io
+$ kubectl delete crd/natsclusters.nats.io
+
 ```
 
 The command removes all the Kubernetes components associated with the chart and


### PR DESCRIPTION
When we want to delete or reinstall NATS-Operator chart, we must ensure that our CRD are uninstalled first. This is because the chart uses helm.sh/hook-delete-policy: before-hook-creation for both its CRD's. Since those CRD's are marked with `scope: Namespaced`, it means it's safe to delete a namespaced instance of NATS-Operator without affecting other instances. People then should be able to understand by themselves why they are getting errors like `Error: object is being deleted: customresourcedefinitions.apiextensions.k8s.io "natsserviceroles.nats.io" already exists`

[See the official Helm documentation](https://github.com/helm/helm/blob/master/docs/charts_hooks.md#automatically-delete-hook-from-previous-release)

