### PR TITLE
Upgrade to Kuberenetes 1.13 to resolve #187

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,20 +37,20 @@
   revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
 
 [[projects]]
+  digest = "1:8466756c66127d5ea10cc6c305a16174755ebd187e64ec2b4efc3eef58281dcd"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5858425f75500d40c52783dce87d085a483ce135"
+  version = "v4.2.0"
+
+[[projects]]
   digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   pruneopts = ""
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
-
-[[projects]]
-  digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
-  name = "github.com/ghodss/yaml"
-  packages = ["."]
-  pruneopts = ""
-  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
-  version = "v1.0.0"
 
 [[projects]]
   digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
@@ -62,14 +62,6 @@
   pruneopts = ""
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
-
-[[projects]]
-  branch = "master"
-  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  pruneopts = ""
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   branch = "master"
@@ -423,7 +415,7 @@
   version = "v2.2.1"
 
 [[projects]]
-  digest = "1:3e3e9df293bd6f9fd64effc9fa1f0edcd97e6c74145cd9ab05d35719004dc41f"
+  digest = "1:8a3902b1f1aab51953de9741e4a62daaab441788d85ba7f50709ceca8e26b6ff"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -431,6 +423,7 @@
     "apps/v1",
     "apps/v1beta1",
     "apps/v1beta2",
+    "auditregistration/v1alpha1",
     "authentication/v1",
     "authentication/v1beta1",
     "authorization/v1",
@@ -459,11 +452,11 @@
     "storage/v1beta1",
   ]
   pruneopts = ""
-  revision = "6db15a15d2d3874a6c3ddb2140ac9f3bc7058428"
-  version = "kubernetes-1.12.4"
+  revision = "5cb15d34447165a97c76ed5a60e4e99c8a01ecfe"
+  version = "kubernetes-1.13.6"
 
 [[projects]]
-  digest = "1:0514030578b0b83dbca9b0e313ba99e5c905b9a4aba5e115172c521beb6b03b2"
+  digest = "1:b7baa49dee7b63d0e0eafb859055fcdbe4cb86e5c5185e3a2c25e36c56f95bcc"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -473,11 +466,11 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = ""
-  revision = "853f76028711219c2fc251fd5184f23fd44a7aa0"
-  version = "kubernetes-1.12.4"
+  revision = "007dc40467c53cdf06a571fc4c0d6479407de1aa"
+  version = "kubernetes-1.13.6"
 
 [[projects]]
-  digest = "1:8cac653dd97e89700e00ce6ea7134cf28b3e1b59615ab99464760e230fab9860"
+  digest = "1:c05610391a133b223e1736a3b8cbd725da30f64c0c6a93d6422714ccfd8f4a73"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -529,11 +522,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
-  revision = "49ce2735e5074ffc3f8190c8406cf51a96302dad"
-  version = "kubernetes-1.12.4"
+  revision = "86fb29eff6288413d76bd8506874fddd9fccdff0"
+  version = "kubernetes-1.13.6"
 
 [[projects]]
-  digest = "1:bdb1a78c989d28368500c7c5026c08492e6fb530f22d69310b13c6ee82cfebfb"
+  digest = "1:99b73e1dffcff759d6de291835099406f58222e7ec2f11d0efc0594ce97c4cdf"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -546,6 +539,8 @@
     "informers/apps/v1",
     "informers/apps/v1beta1",
     "informers/apps/v1beta2",
+    "informers/auditregistration",
+    "informers/auditregistration/v1alpha1",
     "informers/autoscaling",
     "informers/autoscaling/v1",
     "informers/autoscaling/v2beta1",
@@ -589,6 +584,7 @@
     "kubernetes/typed/apps/v1",
     "kubernetes/typed/apps/v1beta1",
     "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/auditregistration/v1alpha1",
     "kubernetes/typed/authentication/v1",
     "kubernetes/typed/authentication/v1beta1",
     "kubernetes/typed/authorization/v1",
@@ -620,6 +616,7 @@
     "listers/apps/v1",
     "listers/apps/v1beta1",
     "listers/apps/v1beta2",
+    "listers/auditregistration/v1alpha1",
     "listers/autoscaling/v1",
     "listers/autoscaling/v2beta1",
     "listers/autoscaling/v2beta2",
@@ -680,8 +677,16 @@
     "util/workqueue",
   ]
   pruneopts = ""
-  revision = "5e6a3d4e34f694e895b13ae728111e726a5b69df"
-  version = "kubernetes-1.12.4"
+  revision = "65905f29c17c1f14e6485158af1072d74ddb4e9d"
+  version = "kubernetes-1.13.6"
+
+[[projects]]
+  digest = "1:4b78eccecdf36f29cacc19ca79411f2235e0387af52b11f1d77328d7ad5d84a2"
+  name = "k8s.io/klog"
+  packages = ["."]
+  pruneopts = ""
+  revision = "e531227889390a39d9533dde61f590fe9f4b0035"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
@@ -701,6 +706,14 @@
   pruneopts = ""
   revision = "17c77c7898218073f14c8d573582e8d2313dc740"
   version = "v1.12.2"
+
+[[projects]]
+  digest = "1:321081b4a44256715f2b68411d8eda9a17f17ebfe6f0cc61d2cc52d11c08acfa"
+  name = "sigs.k8s.io/yaml"
+  packages = ["."]
+  pruneopts = ""
+  revision = "fd68e9863619f6ec2fdd8625fe1f02e7c877e480"
+  version = "v1.1.0"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -737,7 +750,6 @@
     "k8s.io/client-go/informers",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
-    "k8s.io/client-go/kubernetes/typed/apps/v1beta1",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/listers/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,19 +16,19 @@
 
 [[constraint]]
   name = "k8s.io/api"
-  version = "kubernetes-1.12.4"
+  version = "kubernetes-1.13.6"
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  version = "kubernetes-1.12.4"
+  version = "kubernetes-1.13.6"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.12.4"
+  version = "kubernetes-1.13.6"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.12.4"
+  version = "kubernetes-1.13.6"
 
 [[override]]
   name = "gopkg.in/fsnotify.v1"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build.operator: gen
 
 # dep fetches required dependencies.
 .PHONY: dep
-dep: KUBERNETES_VERSION := 1.12.4
+dep: KUBERNETES_VERSION := 1.13.6
 dep: KUBERNETES_CODE_GENERATOR_PKG := k8s.io/code-generator
 dep: KUBERNETES_APIMACHINERY_PKG := k8s.io/apimachinery
 dep:

--- a/pkg/client/clientset/versioned/typed/nats/v1alpha2/fake/fake_natscluster.go
+++ b/pkg/client/clientset/versioned/typed/nats/v1alpha2/fake/fake_natscluster.go
@@ -117,7 +117,7 @@ func (c *FakeNatsClusters) DeleteCollection(options *v1.DeleteOptions, listOptio
 // Patch applies the patch and returns the patched natsCluster.
 func (c *FakeNatsClusters) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha2.NatsCluster, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(natsclustersResource, c.ns, name, data, subresources...), &v1alpha2.NatsCluster{})
+		Invokes(testing.NewPatchSubresourceAction(natsclustersResource, c.ns, name, pt, data, subresources...), &v1alpha2.NatsCluster{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset/versioned/typed/nats/v1alpha2/fake/fake_natsservicerole.go
+++ b/pkg/client/clientset/versioned/typed/nats/v1alpha2/fake/fake_natsservicerole.go
@@ -117,7 +117,7 @@ func (c *FakeNatsServiceRoles) DeleteCollection(options *v1.DeleteOptions, listO
 // Patch applies the patch and returns the patched natsServiceRole.
 func (c *FakeNatsServiceRoles) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha2.NatsServiceRole, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(natsservicerolesResource, c.ns, name, data, subresources...), &v1alpha2.NatsServiceRole{})
+		Invokes(testing.NewPatchSubresourceAction(natsservicerolesResource, c.ns, name, pt, data, subresources...), &v1alpha2.NatsServiceRole{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset/versioned/typed/nats/v1alpha2/natscluster.go
+++ b/pkg/client/clientset/versioned/typed/nats/v1alpha2/natscluster.go
@@ -17,6 +17,8 @@
 package v1alpha2
 
 import (
+	"time"
+
 	v1alpha2 "github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
 	scheme "github.com/nats-io/nats-operator/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,11 +75,16 @@ func (c *natsClusters) Get(name string, options v1.GetOptions) (result *v1alpha2
 
 // List takes label and field selectors, and returns the list of NatsClusters that match those selectors.
 func (c *natsClusters) List(opts v1.ListOptions) (result *v1alpha2.NatsClusterList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	result = &v1alpha2.NatsClusterList{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("natsclusters").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Do().
 		Into(result)
 	return
@@ -85,11 +92,16 @@ func (c *natsClusters) List(opts v1.ListOptions) (result *v1alpha2.NatsClusterLi
 
 // Watch returns a watch.Interface that watches the requested natsClusters.
 func (c *natsClusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
 		Resource("natsclusters").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Watch()
 }
 
@@ -131,10 +143,15 @@ func (c *natsClusters) Delete(name string, options *v1.DeleteOptions) error {
 
 // DeleteCollection deletes a collection of objects.
 func (c *natsClusters) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	var timeout time.Duration
+	if listOptions.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("natsclusters").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Timeout(timeout).
 		Body(options).
 		Do().
 		Error()

--- a/pkg/client/clientset/versioned/typed/nats/v1alpha2/natsservicerole.go
+++ b/pkg/client/clientset/versioned/typed/nats/v1alpha2/natsservicerole.go
@@ -17,6 +17,8 @@
 package v1alpha2
 
 import (
+	"time"
+
 	v1alpha2 "github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
 	scheme "github.com/nats-io/nats-operator/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,11 +75,16 @@ func (c *natsServiceRoles) Get(name string, options v1.GetOptions) (result *v1al
 
 // List takes label and field selectors, and returns the list of NatsServiceRoles that match those selectors.
 func (c *natsServiceRoles) List(opts v1.ListOptions) (result *v1alpha2.NatsServiceRoleList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	result = &v1alpha2.NatsServiceRoleList{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("natsserviceroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Do().
 		Into(result)
 	return
@@ -85,11 +92,16 @@ func (c *natsServiceRoles) List(opts v1.ListOptions) (result *v1alpha2.NatsServi
 
 // Watch returns a watch.Interface that watches the requested natsServiceRoles.
 func (c *natsServiceRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
 		Resource("natsserviceroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Watch()
 }
 
@@ -131,10 +143,15 @@ func (c *natsServiceRoles) Delete(name string, options *v1.DeleteOptions) error 
 
 // DeleteCollection deletes a collection of objects.
 func (c *natsServiceRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	var timeout time.Duration
+	if listOptions.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("natsserviceroles").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Timeout(timeout).
 		Body(options).
 		Do().
 		Error()

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -25,6 +25,7 @@ import (
 	cache "k8s.io/client-go/tools/cache"
 )
 
+// NewInformerFunc takes versioned.Interface and time.Duration to return a SharedIndexInformer.
 type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
@@ -33,4 +34,5 @@ type SharedInformerFactory interface {
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 
+// TweakListOptionsFunc is a function that transforms a v1.ListOptions.
 type TweakListOptionsFunc func(*v1.ListOptions)


### PR DESCRIPTION
This upgrades the dependencies and regenerates the API client classes to work with 1.13. This should resolve #187 and make it easier for anyone who is using apimachinery:kubernetes-1.13 or higher to include this project as a dependency. 