### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License Apache 2.0](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Build Status](https://travis-ci.org/nats-io/nats-operator.svg?branch=master)](https://travis-ci.org/nats-io/nats-operator)
-[![Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=go&type=5&v=0.4.5)](https://github.com/nats-io/nats-operator/releases/tag/v0.4.5)
+[![Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=go&type=5&v=0.5.0)](https://github.com/nats-io/nats-operator/releases/tag/v0.5.0)
 
 NATS Operator manages NATS clusters atop [Kubernetes][k8s-home], automating their creation and administration.
 
@@ -45,8 +45,8 @@ The operation mode must be chosen when installing NATS Operator and cannot be ch
 To perform a namespace-scoped installation of NATS Operator in the Kubernetes cluster pointed at by the current context, you may run:
 
 ```console
-$ kubectl apply -f https://github.com/nats-io/nats-operator/releases/download/v0.4.5/00-prereqs.yaml
-$ kubectl apply -f https://github.com/nats-io/nats-operator/releases/download/v0.4.5/10-deployment.yaml
+$ kubectl apply -f https://github.com/nats-io/nats-operator/releases/download/v0.5.0/00-prereqs.yaml
+$ kubectl apply -f https://github.com/nats-io/nats-operator/releases/download/v0.5.0/10-deployment.yaml
 ``` 
 
 This will, by default, install NATS Operator in the `default` namespace and observe `NatsCluster` resources created in the `default` namespace, alone.

--- a/deploy/10-deployment.yaml
+++ b/deploy/10-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: nats-operator
       containers:
       - name: nats-operator
-        image: connecteverything/nats-operator:0.4.5-v1alpha2
+        image: connecteverything/nats-operator:0.5.0-v1alpha2
         imagePullPolicy: IfNotPresent
         args:
         - nats-operator

--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -155,7 +155,7 @@ type ServerConfig struct {
 // OperatorConfig is the operator configuration from a server.
 type OperatorConfig struct {
 	Secret        string `json:"secret,omitempty"`
-	SystemAccount string `json:"account,omitempty"`
+	SystemAccount string `json:"systemAccount,omitempty"`
 	Resolver      string `json:"resolver,omitempty"`
 }
 


### PR DESCRIPTION
### Changelog

This version adds support for NATS v2 new decentralized auth features, and super clusters using gateway and leafnodes.  Full example below:

```yaml
---
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "nats-super-cluster"

spec:
  size: 3
  version: "edge-v2.0.0-RC12"
  serverImage: "synadia/nats-server"

  natsConfig:
    debug: true
    trace: true

  tls:
    # TLS timeout for client connections
    clientsTLSTimeout: 5

    # TLS timeout for gateway connections
    gatewaysTLSTimeout: 5

    # Certificates to secure the NATS client connections:
    serverSecret: "nats-server-tls"

    # Name of the CA in serverSecret
    serverSecretCAFileName: "ca.crt"

    # Name of the key in serverSecret
    serverSecretKeyFileName: "tls.key"

    # Name of the certificate in serverSecret
    serverSecretCertFileName: "tls.crt"

    # Certificates to secure the routes.
    routesSecret: "nats-routes-tls"

    # Name of the CA in routesSecret
    routesSecretCAFileName: "ca.crt"

    # Name of the key in routesSecret
    routesSecretKeyFileName: "tls.key"

    # Name of the certificate in routesSecret
    routesSecretCertFileName: "tls.crt"

    # Certificates to secure the routes.
    gatewaySecret: "nats-gateways-tls"

    # Name of the CA in routesSecret
    gatewaySecretCAFileName: "ca.crt"

    # Name of the key in gatewaySecret
    gatewaySecretKeyFileName: "tls.key"

    # Name of the certificate in routesSecret
    gatewaySecretCertFileName: "tls.crt"

    # Certificates to secure the routes.
    leafnodeSecret: "nats-leafnodes-tls"

    # Name of the CA in routesSecret
    leafnodeSecretCAFileName: "ca.crt"

    # Name of the key in routesSecret
    leafnodeSecretKeyFileName: "tls.key"

    # Name of the certificate in routesSecret
    leafnodeSecretCertFileName: "tls.crt"

  pod:
    enableClientsHostPort: true
    advertiseExternalIP: true

  gatewayConfig:
    name: minikube
    hostPort: 32328

    gateways:
    - name: minikube
      url: nats://127.0.0.1:32328

  leafnodeConfig:
    hostPort: 4224

  operatorConfig:
    secret: operator-jwt
    systemAccount: "AASYS..."
    resolver: URL(https://example.com/jwt/v1/accounts/)

  template:
    spec:
      # Required to be able to lookup public ip address from a server.
      serviceAccountName: "nats-server"
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>