### PR TITLE
Update to use NATS v2 image by default

### DIFF
--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -45,7 +45,7 @@ func (c *Cluster) reconcileSize() error {
 		// Remove extra pods as required in order to meet the desired size.
 		// As we remove each pod, we must update the config secret so that routes are re-computed.
 		for idx := currentSize - 1; idx >= desiredSize; idx-- {
-			if err := c.tryGracefulPodDeletion(pods[idx]); err != nil {
+			if err := c.tryGracefulPodDeletion(pods[idx], c.cluster.Spec.Version); err != nil {
 				return err
 			}
 			if err := c.updateConfigSecret(); err != nil {
@@ -94,7 +94,7 @@ func (c *Cluster) reconcileVersion() error {
 		for _, pod := range pods {
 			if kubernetesutil.GetNATSVersion(pod) != c.cluster.Spec.Version {
 				c.maybeUpgradeMgmtService()
-				return c.upgradePod(pod)
+				return c.upgradePod(pod, desiredVersion)
 			}
 		}
 	}

--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -29,8 +29,8 @@ import (
 // In order to do that, we first try to make NATS enter the "lame duck" mode.
 // If we succeed, we adopt a special upgrade procedure since the pod (or at least its "nats" container) will have been terminated and can't be upgraded directly.
 // If we fail, we stick to the usual method of upgrading the container's "image" field to the desired version.
-func (c *Cluster) upgradePod(pod *v1.Pod) error {
-	if err := c.enterLameDuckModeAndWaitTermination(pod); err != nil {
+func (c *Cluster) upgradePod(pod *v1.Pod, version string) error {
+	if err := c.enterLameDuckModeAndWaitTermination(pod, version); err != nil {
 		c.logger.Warn(err)
 		return c.upgradeRunningPod(pod)
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -16,7 +16,7 @@ package constants
 
 const (
 	// DefaultNatsVersion is the nats server version to use.
-	DefaultNatsVersion = "1.4.0"
+	DefaultNatsVersion = "2.0.0"
 
 	// ClientPort is the port for the clients.
 	ClientPort = 4222
@@ -58,7 +58,7 @@ const (
 	PidFileVolumeName = "pid"
 
 	// PidFileName is the pid file name.
-	PidFileName = "gnatsd.pid"
+	PidFileName = "nats.pid"
 
 	// PidFileMountPath is the absolute path to the directory where NATS
 	// will be leaving its pid file.
@@ -128,8 +128,6 @@ const (
 	DefaultBootconfigImage         = "connecteverything/nats-boot-config"
 	DefaultBootconfigImageTag      = "0.5.2"
 
-	// NatsBinaryPath is the path to the NATS binary inside the main container.
-	NatsBinaryPath = "/gnatsd"
 	// NatsContainerName is the name of the main container.
 	NatsContainerName = "nats"
 

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -45,6 +45,7 @@ import (
 	"github.com/nats-io/nats-operator/pkg/conf"
 	"github.com/nats-io/nats-operator/pkg/constants"
 	"github.com/nats-io/nats-operator/pkg/util/retryutil"
+	"github.com/nats-io/nats-operator/pkg/util/versionCheck"
 )
 
 const (
@@ -920,7 +921,7 @@ func NewNatsPodSpec(namespace, name, clusterName string, cs v1alpha2.ClusterSpec
 	// Rely on the shared configuration map for configuring the cluster.
 	retries := strconv.Itoa(constants.ConnectRetries)
 	cmd := []string{
-		constants.NatsBinaryPath,
+		versionCheck.ServerBinaryPath(cs.Version),
 		"-c",
 		constants.ConfigFilePath,
 		"-P",

--- a/pkg/util/versionCheck/versionCheck.go
+++ b/pkg/util/versionCheck/versionCheck.go
@@ -1,0 +1,29 @@
+package versionCheck
+
+import (
+	"strconv"
+	"strings"
+)
+
+const (
+	// OldNatsBinaryPath is the path to the NATS binary inside the
+	// main container, before NATS Server v2.
+	OldNatsBinaryPath = "/gnatsd"
+
+	// NatsBinaryPath after v2 release.
+	NatsBinaryPath = "/nats-server"
+)
+
+func ServerBinaryPath(version string) string {
+	v := strings.Split(version, ".")
+	if len(v) > 0 {
+		majorVersion, err := strconv.Atoi(v[0])
+		if err != nil {
+			return NatsBinaryPath
+		}
+		if majorVersion < 2 {
+			return OldNatsBinaryPath
+		}
+	}
+	return NatsBinaryPath
+}

--- a/pkg/util/versionCheck/versionCheck_test.go
+++ b/pkg/util/versionCheck/versionCheck_test.go
@@ -1,0 +1,37 @@
+package versionCheck
+
+import (
+	"testing"
+)
+
+func TestServerBinaryPath(t *testing.T) {
+	got := ServerBinaryPath("2.0.0")
+	expected := NatsBinaryPath
+	if got != expected {
+		t.Fatalf("Expected %q, got: %q", expected, got)
+	}
+
+	got = ServerBinaryPath("2.1.8")
+	expected = NatsBinaryPath
+	if got != expected {
+		t.Fatalf("Expected %q, got: %q", expected, got)
+	}
+
+	got = ServerBinaryPath("2.1.8-RC18")
+	expected = NatsBinaryPath
+	if got != expected {
+		t.Fatalf("Expected %q, got: %q", expected, got)
+	}
+
+	got = ServerBinaryPath("0.1.8")
+	expected = OldNatsBinaryPath
+	if got != expected {
+		t.Fatalf("Expected %q, got: %q", expected, got)
+	}
+
+	got = ServerBinaryPath("1.4.1")
+	expected = OldNatsBinaryPath
+	if got != expected {
+		t.Fatalf("Expected %q, got: %q", expected, got)
+	}
+}

--- a/test/e2e/lame_duck_mode_test.go
+++ b/test/e2e/lame_duck_mode_test.go
@@ -42,10 +42,8 @@ func TestLameDuckModeWhenScalingDown(t *testing.T) {
 	var (
 		initialSize = 3
 		finalSize   = 1
-		// TODO Replace with an adequate stable tag once there is one.
-		version = "5d86964"
-		// TODO Remove once the "nats" image has an adequate stable tag.
-		serverImage = "natsop2018/gnatsd"
+		serverImage = "synadia/nats-server"
+		version     = "2.0.0"
 	)
 
 	var (

--- a/test/e2e/super_cluster_test.go
+++ b/test/e2e/super_cluster_test.go
@@ -32,15 +32,13 @@ import (
 func TestCreateServerWithGateways(t *testing.T) {
 	var (
 		size    = 1
-		image   = "synadia/nats-server"
-		version = "edge-v2.0.0-RC12"
+		version = "2.0.0"
 		nc      *natsv1alpha2.NatsCluster
 		err     error
 	)
 	nc, err = f.CreateCluster(f.Namespace, "", size, version,
 		func(cluster *natsv1alpha2.NatsCluster) {
 			cluster.Name = "test-nats-gw"
-			cluster.Spec.ServerImage = image
 
 			cluster.Spec.ServerConfig = &natsv1alpha2.ServerConfig{
 				Debug: true,
@@ -138,7 +136,7 @@ func TestCreateServerWithGatewayAndLeafnodes(t *testing.T) {
 	var (
 		size    = 1
 		image   = "synadia/nats-server"
-		version = "edge-v2.0.0-RC12"
+		version = "2.0.0"
 		nc      *natsv1alpha2.NatsCluster
 		err     error
 

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -144,8 +144,7 @@ func TestCreateClusterWithVerifyAndMap(t *testing.T) {
 		// The NatsCluster resource must be called "nats" in
 		// order for the pre-provisioned certificates to work.
 		natsCluster.Name = "nats-verify"
-		natsCluster.Spec.ServerImage = "wallyqs/nats-server"
-		natsCluster.Spec.Version = "edge-2.0.0-RC5"
+		natsCluster.Spec.Version = "2.0.0"
 
 		// Enable TLS using pre-provisioned certificates.
 		natsCluster.Spec.TLS = &natsv1alpha2.TLSConfig{

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	OperatorVersion = "0.5.0-v1alpha2+git"
+	OperatorVersion = "0.6.0-v1alpha2+git"
 	GitSHA          = "Not provided"
 )


### PR DESCRIPTION
Added also handling to use `/nats-server` when using v2.0 images.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>