### PR TITLE
Remove v1alpha2+git from version label

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	OperatorVersion = "0.6.0-v1alpha2+git"
+	OperatorVersion = "0.6.0"
 	GitSHA          = "Not provided"
 )


### PR DESCRIPTION
Currently when starting the operator it logs the following:

```bash
time="2019-06-18T20:43:25Z" level=info msg="nats-operator Version: 0.6.0-v1alpha2+git"
time="2019-06-18T20:43:25Z" level=info msg="Git SHA: 6f3e8b2"
```

This PR removes the v1alpha2+git from the version label, since commit is also logged in the next line either way.