### PR TITLE
Change service for clients into headless

### DIFF
--- a/hack/e2e/prepare-secrets.sh
+++ b/hack/e2e/prepare-secrets.sh
@@ -39,7 +39,7 @@ cfssl gencert \
   -ca=ca.pem \
   -ca-key=ca-key.pem \
   -config=ca-config.json \
-  -hostname="nats-mgmt,*.nats-mgmt,*.nats-mgmt.${NAMESPACE},*.nats-mgmt.${NAMESPACE}.svc,*.nats-mgmt.${NAMESPACE}.svc.cluster.local" \
+  -hostname="nats,*.nats,*.nats.${NAMESPACE},*.nats.${NAMESPACE}.svc,*.nats.${NAMESPACE}.svc.cluster.local,nats-mgmt,*.nats-mgmt,*.nats-mgmt.${NAMESPACE},*.nats-mgmt.${NAMESPACE}.svc,*.nats-mgmt.${NAMESPACE}.svc.cluster.local" \
   -profile=nats \
   route-csr.json | cfssljson -bare route
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -234,7 +234,7 @@ func (c *Cluster) checkServices() error {
 	)
 
 	// Check whether the client service already exists.
-	if _, err := c.config.ServiceLister.Services(c.cluster.Namespace).Get(kubernetesutil.ClientServiceName(c.cluster.Name)); err != nil {
+	if _, err := c.config.ServiceLister.Services(c.cluster.Namespace).Get(kubernetesutil.ServiceName(c.cluster.Name)); err != nil {
 		if kubernetesutil.IsKubernetesResourceNotFoundError(err) {
 			// The client service does not exist, so we must create it.
 			mustCreateClientService = true
@@ -246,7 +246,7 @@ func (c *Cluster) checkServices() error {
 
 	// Create the client service if required.
 	if mustCreateClientService {
-		if err := kubernetesutil.CreateClientService(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner()); err != nil {
+		if err := kubernetesutil.CreateService(c.config.KubeCli, c.cluster.Name, c.cluster.Spec.Version, c.cluster.Namespace, c.cluster.AsOwner()); err != nil {
 			return err
 		}
 	}

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -93,7 +93,7 @@ func (c *Cluster) reconcileVersion() error {
 		// Iterate over pods, upgrading them as necessary.
 		for _, pod := range pods {
 			if kubernetesutil.GetNATSVersion(pod) != c.cluster.Spec.Version {
-				c.maybeUpgradeMgmtService()
+				c.maybeUpgradeService()
 				return c.upgradePod(pod, desiredVersion)
 			}
 		}

--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -85,9 +85,9 @@ func (c *Cluster) upgradeTerminatedPod(pod *v1.Pod) error {
 	return nil
 }
 
-func (c *Cluster) maybeUpgradeMgmtService() error {
+func (c *Cluster) maybeUpgradeService() error {
 	ns := c.cluster.Namespace
-	sn := kubernetesutil.ManagementServiceName(c.cluster.Name)
+	sn := kubernetesutil.ServiceName(c.cluster.Name)
 
 	svc, err := c.config.KubeCli.Services(ns).Get(sn, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -101,6 +101,12 @@ func ServiceName(clusterName string) string {
 	return clusterName
 }
 
+// ClientServiceName returns the name of the service based on the specified cluster name.
+func ClientServiceName(clusterName string) string {
+	return clusterName
+}
+
+// ManagementServiceName returns the name of the service based on the specified cluster name.
 func ManagementServiceName(clusterName string) string {
 	return clusterName + "-mgmt"
 }

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -39,16 +39,6 @@ import (
 // natsPodContainer returns a NATS server pod container spec.
 func natsPodContainer(clusterName, version string, serverImage string, enableClientsHostPort bool, gatewayPort int, leafnodePort int) v1.Container {
 	container := v1.Container{
-		Env: []v1.EnvVar{
-			{
-				Name:  "SVC",
-				Value: ManagementServiceName(clusterName),
-			},
-			{
-				Name:  "EXTRA",
-				Value: fmt.Sprintf("--http_port=%d", constants.MonitoringPort),
-			},
-		},
 		Name:  constants.NatsContainerName,
 		Image: MakeNATSImage(version, serverImage),
 	}

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ import (
 func TestCreateCluster(t *testing.T) {
 	var (
 		size    = 3
-		version = "1.3.0"
+		version = "1.4.0"
 	)
 
 	var (
@@ -98,7 +99,7 @@ func TestPauseControl(t *testing.T) {
 	var (
 		initialSize = 3
 		finalSize   = 5
-		version     = "1.3.0"
+		version     = "2.0.0"
 	)
 
 	var (
@@ -160,7 +161,7 @@ func TestPauseControl(t *testing.T) {
 func TestCreateClusterWithHostPort(t *testing.T) {
 	var (
 		size    = 1
-		version = "1.3.0"
+		version = "1.4.0"
 	)
 
 	var (
@@ -378,7 +379,7 @@ func TestCreateServerWithCustomConfig(t *testing.T) {
 func TestCreateAndDeleteClusterDependencies(t *testing.T) {
 	var (
 		size        = 1
-		version     = "1.4.0"
+		version     = "2.0.0"
 		natsCluster *natsv1alpha2.NatsCluster
 		err         error
 	)
@@ -399,6 +400,7 @@ func TestCreateAndDeleteClusterDependencies(t *testing.T) {
 
 		// Wait for a single pod to be created.
 		pods, err := f.PodsForNatsCluster(natsCluster)
+		fmt.Println("FOUND! ", pods)
 		if err != nil {
 			return false, err
 		}
@@ -408,6 +410,7 @@ func TestCreateAndDeleteClusterDependencies(t *testing.T) {
 
 		// Confirm that there is a service for the NatsCluster.
 		svcs, err := f.ServicesForNatsCluster(natsCluster)
+		fmt.Println("FOUND: ", svcs)
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/cluster_scoped_test.go
+++ b/test/e2e/cluster_scoped_test.go
@@ -32,7 +32,7 @@ func TestCreateClusterInDedicatedNamespace(t *testing.T) {
 
 	var (
 		size    = 3
-		version = "1.3.0"
+		version = "1.4.0"
 	)
 
 	var (

--- a/test/e2e/config_reload_test.go
+++ b/test/e2e/config_reload_test.go
@@ -32,16 +32,15 @@ import (
 	"github.com/nats-io/nats-operator/test/e2e/framework"
 )
 
-// TestConfigReloadOnResize creates a NatsCluster resource with size 1 and then scales it up to 3 members.
-// It then waits for a log message on the very first pod indicating that the configuration has been reloaded (since its configuration secret has been updated).
-func TestConfigReloadOnResize(t *testing.T) {
+// TestClusterResize creates a NatsCluster resource with size 1 and then scales it up to 3 members.
+func TestClusterResize(t *testing.T) {
 	// Skip the test if "ShareProcessNamespace" is not enabled.
 	f.Require(t, framework.ShareProcessNamespace)
 
 	var (
 		initialSize = 1
 		finalSize   = 3
-		version     = "1.3.0"
+		version     = "2.0.0"
 	)
 
 	var (
@@ -85,13 +84,6 @@ func TestConfigReloadOnResize(t *testing.T) {
 	if err = f.WaitUntilFullMeshWithVersion(ctx2, natsCluster, finalSize, version); err != nil {
 		t.Fatal(err)
 	}
-
-	// Wait for the "Reloaded: cluster routes" log message to appear in the logs for the very first pod.
-	ctx3, fn := context.WithTimeout(context.Background(), waitTimeout)
-	defer fn()
-	if err = f.WaitUntilPodLogLineMatches(ctx3, natsCluster, 1, "Reloaded: cluster routes"); err != nil {
-		t.Fatal(err)
-	}
 }
 
 // TestConfigReloadOnClientAuthSecretChange creates a secret containing authentication data for a NATS cluster.
@@ -131,7 +123,7 @@ func TestConfigReloadOnClientAuthFileChange(t *testing.T) {
 		natsCluster.Spec.Pod = &natsv1alpha2.PodPolicy{
 			// Enable configuration reloading.
 			EnableConfigReload:      true,
-			ReloaderImage:           "wallyqs/nats-server-config-reloader",
+			ReloaderImage:           "connecteverything/nats-server-config-reloader",
 			ReloaderImageTag:        "0.4.5-v1alpha2",
 			ReloaderImagePullPolicy: "Always",
 			VolumeMounts: []v1.VolumeMount{
@@ -173,7 +165,7 @@ func ConfigReloadTestHelper(t *testing.T, customizer NatsClusterCustomizerWSecre
 		password1 = "pass-1"
 		password2 = "pass-2"
 		size      = 1
-		version   = "1.4.0"
+		version   = "2.0.0"
 	)
 
 	var (
@@ -326,7 +318,7 @@ func TestConfigReloadOnNatsServiceRoleUpdates(t *testing.T) {
 		clusterName = "test-nats-nsr"
 		size        = 1
 		subject     = "hello.world"
-		version     = "1.3.0"
+		version     = "1.4.0"
 	)
 
 	var (

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -33,7 +33,7 @@ import (
 func TestConfigContainsFullMesh(t *testing.T) {
 	var (
 		size    = 3
-		version = "1.3.0"
+		version = "1.4.0"
 	)
 
 	var (
@@ -75,7 +75,7 @@ func TestConfigContainsFullMesh(t *testing.T) {
 func TestExistingSecretIsReplaced(t *testing.T) {
 	var (
 		size    = 3
-		version = "1.3.0"
+		version = "1.4.0"
 	)
 
 	var (

--- a/test/e2e/framework/nats.go
+++ b/test/e2e/framework/nats.go
@@ -30,7 +30,9 @@ import (
 // It is the caller's responsibility to close the connection when it is no longer needed.
 func (f *Framework) ConnectToNatsClusterWithUsernamePassword(natsCluster *natsv1alpha2.NatsCluster, username, password string) (*nats.Conn, error) {
 	// Connect to the NATS cluster represented by the specified NatsCluster resource using the specified credentials.
-	c, err := nats.Connect(fmt.Sprintf("nats://%s.%s:%d", kubernetes.ClientServiceName(natsCluster.Name), natsCluster.Namespace, constants.ClientPort), nats.UserInfo(username, password))
+	endpoint := fmt.Sprintf("nats://%s:%d", kubernetes.ServiceName(natsCluster.Name), constants.ClientPort)
+	fmt.Println("----", endpoint)
+	c, err := nats.Connect(endpoint, nats.UserInfo(username, password))
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/framework/natscluster.go
+++ b/test/e2e/framework/natscluster.go
@@ -130,6 +130,8 @@ func (f *Framework) NatsClusterHasExpectedRouteCount(natsCluster *natsv1alpha2.N
 	if err != nil {
 		return false, err
 	}
+	fmt.Println("TOTAL PODS: ", len(pods))
+
 	// Make sure that every pod has routes to every other pod.
 	for _, pod := range pods {
 		r, err := f.RouteCountForPod(pod)
@@ -267,15 +269,9 @@ func (f *Framework) WaitUntilExpectedRoutesInConfig(ctx context.Context, natsClu
 		// List pods belonging to the NATS cluster, and make
 		// sure that every route is listed in the
 		// configuration.
-		pods, err := f.PodsForNatsCluster(natsCluster)
-		if err != nil {
+		route := fmt.Sprintf("nats://%s:%d", kubernetesutil.ServiceName(natsCluster.Name), constants.ClusterPort)
+		if !slice.ContainsString(confObj.Cluster.Routes, route, nil) {
 			return false, nil
-		}
-		for _, pod := range pods {
-			route := fmt.Sprintf("nats://%s.%s.%s.svc:%d", pod.Name, kubernetesutil.ManagementServiceName(natsCluster.Name), natsCluster.Namespace, constants.ClusterPort)
-			if !slice.ContainsString(confObj.Cluster.Routes, route, nil) {
-				return false, nil
-			}
 		}
 
 		// We've found routes to all pods in the configuration!

--- a/test/e2e/resize_test.go
+++ b/test/e2e/resize_test.go
@@ -29,7 +29,7 @@ func TestResizeClusterFrom3To5(t *testing.T) {
 	var (
 		initialSize = 3
 		finalSize   = 5
-		version     = "1.3.0"
+		version     = "2.0.0"
 	)
 
 	var (
@@ -75,7 +75,7 @@ func TestResizeClusterFrom5To3(t *testing.T) {
 	var (
 		initialSize = 5
 		finalSize   = 3
-		version     = "1.3.0"
+		version     = "2.0.0"
 	)
 
 	var (

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -31,7 +31,7 @@ import (
 func TestCreateClusterWithTLSConfig(t *testing.T) {
 	var (
 		size    = 3
-		version = "1.3.0"
+		version = "1.4.0"
 	)
 
 	var (

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -24,16 +24,15 @@ import (
 )
 
 // TestUpgradeCluster creates a NatsCluster resource with version
-// 1.3.0 and waits for the full mesh to be formed.  Then, it updates
-// the ".spec.version" field of the NatsCluster resource to 1.4.0 and
+// waits for the full mesh to be formed.  Then, it updates
+// the ".spec.version" field of the NatsCluster resource to and
 // waits for the upgrade to be performed.
 func TestUpgradeCluster(t *testing.T) {
 	var (
-		initialVersion = "1.3.0"
-		finalVersion   = "1.4.0"
+		initialVersion = "1.4.0"
+		finalVersion   = "1.4.1"
 		size           = 2
 	)
-
 	var (
 		natsCluster *natsv1alpha2.NatsCluster
 		err         error

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	OperatorVersion = "0.6.0-v1alpha2+git"
+	OperatorVersion = "0.7.0-v1alpha2+git"
 	GitSHA          = "Not provided"
 )


### PR DESCRIPTION
This changes both services created by the operator for a cluster into being headless, and uses the name of the headless service as a seed in the routes configuration in order to create the cluster. This seems to work ok and not cause partitions. For example a cluster like the following:

```yaml
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "nats"
spec:
  size: 3
  version: "2.0.0"
```

would result into the following configuration:

```js
{
  "port": 4222,
  "http_port": 8222,
  "cluster": {
    "port": 6222,
    "routes": [
      "nats://nats:6222"
    ]
  }
}
```

This also changes the cluster advertise name that is announced by a pod, so if using TLS for the routes now the certificate has to be a wildcard certificate like: `*.<svc-name>` without the `-mgmt` previous to this change (`nats-route://nats-1.nats.default.svc:6222`)

```
nc nats 6222
INFO {"server_id":"NBW7BH2XN6ELMBUFNNVDPDQQ2Q6VYMLHZFXLBTCVTFARY4CMFPZVXSF3","version":"2.0.0","proto":2,"go":"go1.11.10","host":"nats-1.nats.default.svc","port":6222,"max_payload":1048576,"ip":"nats-route://nats-1.nats.default.svc:6222/","nonce":"Ye33jdjhlNBDNlQ","connect_urls":["10.60.0.11:4222"]} 
```
