### PR TITLE
Change the restart policy to pod to always

### DIFF
--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -960,7 +960,7 @@ func NewNatsPodSpec(namespace, name, clusterName string, cs v1alpha2.ClusterSpec
 
 	// Set default restart policy
 	if pod.Spec.RestartPolicy == "" {
-		pod.Spec.RestartPolicy = v1.RestartPolicyNever
+		pod.Spec.RestartPolicy = v1.RestartPolicyAlways
 	}
 
 	if advertiseExternalIP {


### PR DESCRIPTION
By default, in case of failure and nats server is terminated due to a liveness check fail for example we should let kubectl restart it.