### PR TITLE
Add nkeys support for user authentication

### DIFF
--- a/pkg/conf/natsconf.go
+++ b/pkg/conf/natsconf.go
@@ -89,6 +89,7 @@ type AuthorizationConfig struct {
 type User struct {
 	User        string       `json:"username,omitempty"`
 	Password    string       `json:"password,omitempty"`
+	NKey        string       `json:"nkey,omitempty"`
 	Permissions *Permissions `json:"permissions,omitempty"`
 }
 

--- a/pkg/conf/natsconf_test.go
+++ b/pkg/conf/natsconf_test.go
@@ -244,6 +244,33 @@ func TestConfMarshal(t *testing.T) {
 
 			err: nil,
 		},
+		{
+			input: &ServerConfig{
+				Authorization: &AuthorizationConfig{
+					Users: []*User{
+						{
+							NKey: "foo",
+						},
+						{
+							NKey: "bar",
+						},
+					},
+				},
+			},
+			output: `{
+  "logtime": false,
+  "authorization": {
+    "users": [
+      {
+        "nkey": "foo"
+      },
+      {
+        "nkey": "bar"
+      }
+    ]
+  }
+}`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Changes:

- Add nkey to User struct to allow the configuration of nkey authentication. https://nats-io.github.io/docs/nats_server/nkey_auth.html