### PR TITLE
Add support to define resource requirements for reloader container

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -325,6 +325,9 @@ type PodPolicy struct {
 	// ReloaderImagePullPolicy is the pull policy for the reloader image.
 	ReloaderImagePullPolicy string `json:"reloaderImagePullPolicy,omitempty"`
 
+	// ReloaderResources is the reesource requirements for the reloader container
+	ReloaderResources v1.ResourceRequirements `json:"reloaderResources,omitempty"`
+
 	// EnableMetrics attaches a sidecar to each NATS Server
 	// that will export prometheus metrics.
 	EnableMetrics bool `json:"enableMetrics,omitempty"`

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -991,7 +991,7 @@ func NewNatsPodSpec(namespace, name, clusterName string, cs v1alpha2.ClusterSpec
 			authFilePath = cs.Auth.ClientsAuthFile
 		}
 
-		reloaderContainer := natsPodReloaderContainer(image, imageTag, imagePullPolicy, authFilePath)
+		reloaderContainer := natsPodReloaderContainer(image, imageTag, imagePullPolicy, authFilePath, cs.Pod.ReloaderResources)
 		reloaderContainer.VolumeMounts = volumeMounts
 		containers = append(containers, reloaderContainer)
 	}

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -100,7 +100,7 @@ func natsPodContainer(clusterName, version string, serverImage string, enableCli
 }
 
 // natsPodReloaderContainer returns a NATS server pod container spec for configuration reloader.
-func natsPodReloaderContainer(image, tag, pullPolicy, authFilePath string) v1.Container {
+func natsPodReloaderContainer(image, tag, pullPolicy, authFilePath string, r v1.ResourceRequirements) v1.Container {
 	container := v1.Container{
 		Name:            "reloader",
 		Image:           fmt.Sprintf("%s:%s", image, tag),
@@ -112,6 +112,7 @@ func natsPodReloaderContainer(image, tag, pullPolicy, authFilePath string) v1.Co
 			"-pid",
 			constants.PidFilePath,
 		},
+		Resources: r,
 	}
 	if authFilePath != "" {
 		// The volume is mounted as a subdirectory under the NATS config.


### PR DESCRIPTION
Changes:

- Add ReloaderResources json element to PodPolicy to enable the configuration of resources for the reloader container. This is useful on clusters with resource policies that makes them mandatory.