### PR TITLE
Set apiVersion

### DIFF
--- a/helm/nats-operator/Chart.yaml
+++ b/helm/nats-operator/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: nats-operator
 version: 0.1.2
 appVersion: 0.4.4


### PR DESCRIPTION
apiVersion is required, as per the Helm docs. It is enforced in v2.15.1.

**Error:**
Chart.yaml is missing the required apiVersion.

**Expected behaviour:**
helm lint exits successfully.

