### PR TITLE
Add options for tls cipher and curve preferences

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -280,6 +280,12 @@ type TLSConfig struct {
 
 	// Verify toggles verifying TLS certs for clients.
 	Verify bool `json:"verify,omitempty"`
+
+	// CipherSuites
+	CipherSuites []string `json:"cipherSuites,omitempty"`
+
+	// CurvePreferences
+	CurvePreferences []string `json:"curvePreferences,omitempty"`
 }
 
 // PodPolicy defines the policy to create pod for the NATS container.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The nats-operator Authors
+// Copyright 2017-2020 The nats-operator Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ package constants
 
 const (
 	// DefaultNatsVersion is the nats server version to use.
-	DefaultNatsVersion = "2.0.0"
+	DefaultNatsVersion = "2.1.2"
 
 	// ClientPort is the port for the clients.
 	ClientPort = 4222

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -168,6 +168,10 @@ func addTLSConfig(sconfig *natsconf.ServerConfig, cs v1alpha2.ClusterSpec) {
 
 		// Verifying clients cert is disabled by default.
 		sconfig.TLS.Verify = cs.TLS.Verify
+
+		// Customize cipher suites and curve preferences.
+		sconfig.TLS.CipherSuites = cs.TLS.CipherSuites
+		sconfig.TLS.CurvePreferences = cs.TLS.CurvePreferences
 	}
 	if cs.TLS.RoutesSecret != "" {
 		sconfig.Cluster.TLS = &natsconf.TLSConfig{

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	natsv1alpha2 "github.com/nats-io/nats-operator/pkg/apis/nats/v1alpha2"
@@ -297,6 +298,67 @@ func TestCreateClusterWithVerify(t *testing.T) {
 			return false, nil
 		}
 		if config.TLS == nil || !config.TLS.Verify {
+			return false, nil
+		}
+
+		pods, err := f.PodsForNatsCluster(natsCluster)
+		if err != nil {
+			return false, nil
+		}
+		if len(pods) < 1 {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateClusterWithCustomCiphers(t *testing.T) {
+	natsCluster, err := f.CreateCluster(f.Namespace, "", 1, "", func(natsCluster *natsv1alpha2.NatsCluster) {
+		// The NatsCluster resource must be called "nats" in
+		// order for the pre-provisioned certificates to work.
+		natsCluster.Name = "nats"
+		natsCluster.Spec.ServerImage = "nats"
+		natsCluster.Spec.Version = "1.4.1"
+
+		// Enable TLS using pre-provisioned certificates.
+		natsCluster.Spec.TLS = &natsv1alpha2.TLSConfig{
+			Verify:           true,
+			ServerSecret:     "nats-certs",
+			CipherSuites:     []string{"FOO", "BAR"},
+			CurvePreferences: []string{"HELLO", "WORLD"},
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make sure we cleanup the NatsCluster resource after we're done testing.
+	defer func() {
+		if err = f.DeleteCluster(natsCluster); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Wait until the full mesh is formed.
+	ctx1, fn := context.WithTimeout(context.Background(), waitTimeout)
+	defer fn()
+	err = f.WaitUntilSecretCondition(ctx1, natsCluster, func(event watchapi.Event) (bool, error) {
+		secret := event.Object.(*v1.Secret)
+		conf, ok := secret.Data[constants.ConfigFileName]
+		if !ok {
+			return false, nil
+		}
+		config, err := natsconf.Unmarshal(conf)
+		if err != nil {
+			return false, nil
+		}
+		if config.TLS == nil {
+			return false, nil
+		}
+		fmt.Println(config.TLS.CipherSuites, len(config.TLS.CipherSuites))
+		if len(config.TLS.CipherSuites) != 2 {
 			return false, nil
 		}
 

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	OperatorVersion = "0.6.0-v1alpha2+git"
+	OperatorVersion = "0.6.2-v1alpha2+git"
 	GitSHA          = "Not provided"
 )


### PR DESCRIPTION
Example:

```yaml
---
apiVersion: "nats.io/v1alpha2"
kind: "NatsCluster"
metadata:
  name: "tls-nats"
spec:
  # Number of nodes in the cluster
  size: 3

  tls:
    # Certificates to secure the NATS client connections
    serverSecret: "nats-server-tls"

    # Name of the CA in serverSecret
    serverSecretCAFileName: "ca.crt"

    # Name of the key in serverSecret
    serverSecretKeyFileName: "tls.key"

    # Name of the certificate in serverSecret
    serverSecretCertFileName: "tls.crt"

    cipherSuites:
      - TLS_...

    curvePreferences:
      - example...
```