### PR TITLE
Use correct binary path when entering lame duck mode.

### DIFF
--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -45,7 +45,7 @@ func (c *Cluster) reconcileSize() error {
 		// Remove extra pods as required in order to meet the desired size.
 		// As we remove each pod, we must update the config secret so that routes are re-computed.
 		for idx := currentSize - 1; idx >= desiredSize; idx-- {
-			if err := c.tryGracefulPodDeletion(pods[idx], c.cluster.Spec.Version); err != nil {
+			if err := c.tryGracefulPodDeletion(pods[idx]); err != nil {
 				return err
 			}
 			if err := c.updateConfigSecret(); err != nil {
@@ -94,7 +94,7 @@ func (c *Cluster) reconcileVersion() error {
 		for _, pod := range pods {
 			if kubernetesutil.GetNATSVersion(pod) != c.cluster.Spec.Version {
 				c.maybeUpgradeMgmtService()
-				return c.upgradePod(pod, desiredVersion)
+				return c.upgradePod(pod)
 			}
 		}
 	}

--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -20,7 +20,7 @@ import (
 
 	kubernetesutil "github.com/nats-io/nats-operator/pkg/util/kubernetes"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -29,8 +29,8 @@ import (
 // In order to do that, we first try to make NATS enter the "lame duck" mode.
 // If we succeed, we adopt a special upgrade procedure since the pod (or at least its "nats" container) will have been terminated and can't be upgraded directly.
 // If we fail, we stick to the usual method of upgrading the container's "image" field to the desired version.
-func (c *Cluster) upgradePod(pod *v1.Pod, version string) error {
-	if err := c.enterLameDuckModeAndWaitTermination(pod, version); err != nil {
+func (c *Cluster) upgradePod(pod *v1.Pod) error {
+	if err := c.enterLameDuckModeAndWaitTermination(pod); err != nil {
 		c.logger.Warn(err)
 		return c.upgradeRunningPod(pod)
 	}


### PR DESCRIPTION
When upgrading from 1.4.1 to 2.x.x entering lame duck mode would fail as it would lookup the binary server path for the desired version and not the currently running version. 

This patch uses the currently running pod version to lookup the binary server path.