### PR TITLE
Fix broken image.pullPolicy and bump version to 0.1.3

### DIFF
--- a/helm/nats-operator/Chart.yaml
+++ b/helm/nats-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nats-operator
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.4.4
 description: Nats operator creates/configures/manages nats clusters atop Kubernetes
 keywords:

--- a/helm/nats-operator/templates/deployment.yaml
+++ b/helm/nats-operator/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
       - name: nats-operator
         image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
-        imagePullPolicy: {{ .Values.pullPolicy  }}
+        imagePullPolicy: {{ .Values.image.pullPolicy  }}
         {{- if .Values.clusterScoped }}
         args:
         - nats-operator


### PR DESCRIPTION
Hey guys :)

This PR fixes the reference to `.Values.image.pullPolicy` in the helm deployment, and bumps the chart version accordingly :) The README already correctly references `image.pullPolicy`, so that didn't need an update ;)

Cheers!
D