### PR TITLE
add serviceaccount to cluster-scope example

### DIFF
--- a/example/nats-operator-cluster-scoped.yaml
+++ b/example/nats-operator-cluster-scoped.yaml
@@ -4,6 +4,12 @@ kind: Namespace
 metadata:
   name: nats-io
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-operator
+  namespace: nats-io
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
See issue [example nats-operator-cluster-scoped is missing serviceaccount #276](https://github.com/nats-io/nats-operator/issues/276)