### PR TITLE
Add reload targets to watch TLS secret for watcher

### DIFF
--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -88,7 +87,7 @@ func natsPodContainer(container v1.Container, clusterName, version string, serve
 }
 
 // natsPodReloaderContainer returns a NATS server pod container spec for configuration reloader.
-func natsPodReloaderContainer(image, tag, pullPolicy, authFilePath string, r v1.ResourceRequirements) v1.Container {
+func natsPodReloaderContainer(image, tag, pullPolicy string, r v1.ResourceRequirements, reloadTarget ...string) v1.Container {
 	container := v1.Container{
 		Name:            "reloader",
 		Image:           fmt.Sprintf("%s:%s", image, tag),
@@ -102,11 +101,11 @@ func natsPodReloaderContainer(image, tag, pullPolicy, authFilePath string, r v1.
 		},
 		Resources: r,
 	}
-	if authFilePath != "" {
-		// The volume is mounted as a subdirectory under the NATS config.
-		af := filepath.Join(constants.ConfigMapMountPath, authFilePath)
-		container.Command = append(container.Command, "-config", af)
+
+	for _, v := range reloadTarget {
+		container.Command = append(container.Command, "-config", v)
 	}
+
 	return container
 }
 


### PR DESCRIPTION
related issue: https://github.com/nats-io/nats-operator/issues/239

When Secret resources of TLS certificate depends on a NATSCluster resource, the controller add mount points such resources to monitoring target of configuration reloader.

```
$ kubectl logs nats-cluster-3 -c reloader -f
2020/08/20 10:19:32 Starting NATS Server Reloader v0.7.2
2020/08/20 10:20:38 Event: "/etc/nats-server-tls-certs/..2020_08_20_10_20_38.453710003": CREATE
2020/08/20 10:20:38 Sending signal to server to reload configuration
2020/08/20 10:20:38 Event: "/etc/nats-server-tls-certs/..2020_08_20_10_20_38.453710003": CHMOD
2020/08/20 10:20:38 Sending signal to server to reload configuration
2020/08/20 10:20:38 Event: "/etc/nats-server-tls-certs/..data_tmp": RENAME
2020/08/20 10:20:38 Event: "/etc/nats-server-tls-certs/..data": CREATE
2020/08/20 10:20:38 Sending signal to server to reload configuration
2020/08/20 10:20:38 Event: "/etc/nats-server-tls-certs/..2020_08_20_10_19_31.875482127": REMOVE
```

```
$ kubectl logs nats-cluster-3 -c nats | grep config
[6] 2020/08/20 10:20:38.344795 [INF] Reloaded server configuration
```