### PR TITLE
Merge volumeMounts, rather than replace

### DIFF
--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -1069,7 +1069,11 @@ func NewNatsPodSpec(namespace, name, clusterName string, cs v1alpha2.ClusterSpec
 			"-gf", filepath.Join(constants.ConfigMapMountPath, constants.BootConfigGatewayFilePath),
 		}
 	}
-	container.VolumeMounts = volumeMounts
+	if container.VolumeMounts == nil {
+		container.VolumeMounts = volumeMounts
+	} else {
+		container.VolumeMounts = append(container.VolumeMounts, volumeMounts...)
+	}
 
 	if cs.Pod != nil {
 		container = containerWithRequirements(container, cs.Pod.Resources)


### PR DESCRIPTION
If the template spec for the pod already includes any volumeMount items then we
should preserve them, not replace them.