### PR TITLE
Add parameters to disable HostPorts for gateways, leafnodes and websockets

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -384,6 +384,18 @@ type PodPolicy struct {
 	// also meaning that only a single NATS server can be running on that machine.
 	EnableClientsHostPort bool `json:"enableClientsHostPort,omitempty"`
 
+	// DisableGatewaysHostPort will disable bind a host port for the NATS container gateways port.
+	// Ignored if AdvertiseExternalIP is true.
+	DisableGatewaysHostPort bool `json:"disableGatewaysHostPort,omitempty"`
+
+	// DisableLeafnodesHostPort will disable bind a host port for the NATS container leafnodes port.
+	// Ignored if AdvertiseExternalIP is true.
+	DisableLeafnodesHostPort bool `json:"disableLeafnodesHostPort,omitempty"`
+
+	// DisableWebsocketsHostPort will disable bind a host port for the NATS container websockets port.
+	// Ignored if AdvertiseExternalIP is true.
+	DisableWebsocketsHostPort bool `json:"disableWebsocketsHostPort,omitempty"`
+
 	// AdvertiseExternalIP will configure the client advertise address for a pod
 	// to be the external IP of the pod where it is running.
 	AdvertiseExternalIP bool `json:"advertiseExternalIP,omitempty"`

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -891,17 +891,18 @@ func addOwnerRefToObject(o metav1.Object, r metav1.OwnerReference) {
 // NewNatsPodSpec returns a NATS peer pod specification, based on the cluster specification.
 func NewNatsPodSpec(namespace, name, clusterName string, cs v1alpha2.ClusterSpec, owner metav1.OwnerReference) *v1.Pod {
 	var (
-		enableClientsHostPort bool
-		annotations           = map[string]string{}
-		containers            = make([]v1.Container, 0)
-		volumes               = make([]v1.Volume, 0)
-		volumeMounts          = make([]v1.VolumeMount, 0)
-		labels                = map[string]string{
+		annotations  = map[string]string{}
+		containers   = make([]v1.Container, 0)
+		volumes      = make([]v1.Volume, 0)
+		volumeMounts = make([]v1.VolumeMount, 0)
+		labels       = map[string]string{
 			LabelAppKey:            "nats",
 			LabelClusterNameKey:    clusterName,
 			LabelClusterVersionKey: cs.Version,
 		}
 	)
+	// hostPortsEnabled with default values not breaking current behaviour
+	hostPortsEnabled := hostPorts{clients: false, gateways: true, leafnodes: true, websockets: true}
 
 	// ConfigMap: Volume declaration for the Pod and Container.
 	volume := newNatsConfigMapVolume(clusterName)
@@ -918,7 +919,19 @@ func NewNatsPodSpec(namespace, name, clusterName string, cs v1alpha2.ClusterSpec
 	if cs.Pod != nil {
 		// User supplied volumes and mounts
 		volumeMounts = append(volumeMounts, cs.Pod.VolumeMounts...)
-		enableClientsHostPort = cs.Pod.EnableClientsHostPort
+		hostPortsEnabled.clients = cs.Pod.EnableClientsHostPort
+		// Disabling HostPorts makes no sense when AdvertiseExternalIP is true
+		if !cs.Pod.AdvertiseExternalIP {
+			if cs.Pod.DisableGatewaysHostPort {
+				hostPortsEnabled.gateways = false
+			}
+			if cs.Pod.DisableLeafnodesHostPort {
+				hostPortsEnabled.leafnodes = false
+			}
+			if cs.Pod.DisableWebsocketsHostPort {
+				hostPortsEnabled.websockets = false
+			}
+		}
 	}
 
 	var gatewayPort int
@@ -956,7 +969,7 @@ func NewNatsPodSpec(namespace, name, clusterName string, cs v1alpha2.ClusterSpec
 		clusterName,
 		cs.Version,
 		cs.ServerImage,
-		enableClientsHostPort,
+		hostPortsEnabled,
 		gatewayPort,
 		leafnodePort,
 		websocketPort,

--- a/pkg/util/kubernetes/pod.go
+++ b/pkg/util/kubernetes/pod.go
@@ -35,11 +35,19 @@ import (
 	"github.com/nats-io/nats-operator/pkg/constants"
 )
 
+// hostPorts defines which HostPorts that should be enabled
+type hostPorts struct {
+	clients    bool
+	gateways   bool
+	leafnodes  bool
+	websockets bool
+}
+
 // natsPodContainer returns a NATS server pod container spec.
 func natsPodContainer(
 	container v1.Container,
 	clusterName, version, serverImage string,
-	enableClientsHostPort bool,
+	hostPortsEnabled hostPorts,
 	gatewayPort, leafnodePort, websocketPort int,
 ) v1.Container {
 	container.Name = constants.NatsContainerName
@@ -63,7 +71,7 @@ func natsPodContainer(
 		ContainerPort: int32(constants.ClientPort),
 		Protocol:      v1.ProtocolTCP,
 	}
-	if enableClientsHostPort {
+	if hostPortsEnabled.clients {
 		port.HostPort = int32(constants.ClientPort)
 	}
 	ports = append(ports, port)
@@ -73,7 +81,9 @@ func natsPodContainer(
 			Name:          "gateway",
 			ContainerPort: int32(gatewayPort),
 			Protocol:      v1.ProtocolTCP,
-			HostPort:      int32(gatewayPort),
+		}
+		if hostPortsEnabled.gateways {
+			port.HostPort = int32(gatewayPort)
 		}
 		ports = append(ports, port)
 	}
@@ -82,7 +92,9 @@ func natsPodContainer(
 			Name:          "leaf",
 			ContainerPort: int32(leafnodePort),
 			Protocol:      v1.ProtocolTCP,
-			HostPort:      int32(leafnodePort),
+		}
+		if hostPortsEnabled.leafnodes {
+			port.HostPort = int32(leafnodePort)
 		}
 		ports = append(ports, port)
 	}
@@ -91,7 +103,9 @@ func natsPodContainer(
 			Name:          "websocket",
 			ContainerPort: int32(websocketPort),
 			Protocol:      v1.ProtocolTCP,
-			HostPort:      int32(websocketPort),
+		}
+		if hostPortsEnabled.websockets {
+			port.HostPort = int32(websocketPort)
 		}
 		ports = append(ports, port)
 	}


### PR DESCRIPTION
PR related to https://github.com/nats-io/nats-operator/issues/300

Restructured args for natsPodContainer() a bit and introduced a struct of bools to control if HostPorts should be used or not.

I also added a check against AdvertiseExternalIP which ignores these new parameters if that is true. It makes no sense to advertise external IP without using a HostPort?

Tested in my environment with success.