### PR TITLE
Support for auth on cluster routes

### DIFF
--- a/pkg/apis/nats/v1alpha2/cluster.go
+++ b/pkg/apis/nats/v1alpha2/cluster.go
@@ -35,6 +35,12 @@ const (
 	// the NATS cluster.
 	clientAuthSecretResourceVersionAnnotationKey = "nats.io/cas"
 
+	// clusterAuthSecretResourceVersionAnnotationKey is the key of
+	// the annotation that holds the last-observed resource
+	// version of the secret containing authentication data for
+	// the NATS cluster.
+	clusterAuthSecretResourceVersionAnnotationKey = "nats.io/clas"
+
 	// natsServiceRolesHashAnnotationKey is the key of the
 	// annotation that holds the hash of the comma-separated list
 	// of NatsServiceRole UIDs associated with the NATS cluster.
@@ -422,6 +428,14 @@ type AuthConfig struct {
 
 	// TLSVerifyAndMap toggles verify and map to auth based on TLS certs.
 	TLSVerifyAndMap bool `json:"tlsVerifyAndMap,omitempty"`
+
+	// ClusterAuthSecret is the secret containing the explicit authorization
+	// configuration in JSON.
+	ClusterAuthSecret string `json:"clusterAuthSecret,omitempty"`
+
+	// ClusterAuthTimeout is the time in seconds that the NATS server will
+	// allow to cluster members to send their auth credentials.
+	ClusterAuthTimeout int `json:"clusterAuthTimeout,omitempty"`
 }
 
 func (c *ClusterSpec) Validate() error {
@@ -643,6 +657,26 @@ func (cs *ClusterStatus) appendCondition(c ClusterCondition) {
 
 func scalingReason(from, to int) string {
 	return fmt.Sprintf("scaling cluster from %d to %d peers", from, to)
+}
+
+// GetClusterAuthSecretResourceVersion returns the last-observed resource version of the secret containing authentication data for the NATS cluster.
+func (c *NatsCluster) GetClusterAuthSecretResourceVersion() string {
+	if c.Annotations == nil {
+		return ""
+	}
+	res, ok := c.Annotations[clusterAuthSecretResourceVersionAnnotationKey]
+	if !ok {
+		return ""
+	}
+	return res
+}
+
+// SetClusterAuthSecretResourceVersion sets the last-observed resource version of the secret containing authentication data for the NATS cluster.
+func (c *NatsCluster) SetClusterAuthSecretResourceVersion(v string) {
+	if c.Annotations == nil {
+		c.Annotations = make(map[string]string, 1)
+	}
+	c.Annotations[clusterAuthSecretResourceVersionAnnotationKey] = v
 }
 
 // GetClientAuthSecretResourceVersion returns the last-observed resource version of the secret containing authentication data for the NATS cluster.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	extsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -310,8 +310,9 @@ func (c *Controller) handleObject(obj interface{}) {
 		}
 		// Enqueue all NatsCluster resources which reference the current secret.
 		for _, cluster := range clusters {
-			if cluster.Spec.Auth != nil && cluster.Spec.Auth.ClientsAuthSecret == object.Name {
+			if cluster.Spec.Auth != nil && (cluster.Spec.Auth.ClientsAuthSecret == object.Name || cluster.Spec.Auth.ClusterAuthSecret == object.Name) {
 				c.enqueue(cluster)
+				return
 			}
 		}
 		return


### PR DESCRIPTION
After some investigation, I couldn't make authentication for internal cluster routers work. After looking through the code, I couldn't find anything actually producing it though the json structure for config was defined.

Here's my approach for it. I tested basic scenarios and it seems to work.

Will require an extra secret since cluster auth for routes only supporting one username.

NatCluster definition example:

```yaml
  auth:
    clusterAuthSecret: "nats-routes-credentials"
    clusterAuthTimeout: 1
```

```
apiVersion: v1
kind: Secret
metadata:
  name: nats-routes-credentials
data:
  user.ncreds: <base64 here>
```

json-data which should be base64 in the secret above:

```json
{
  "username": "natsclusteruser",
  "password": "verynicepassword"
}
```

It will produce the following config:

```
    "routes": [
      "nats://natsclusteruser:verynicepassword@nats-nats-1.nats-nats1-mgmt.default.svc:6222",
      "nats://natsclusteruser:verynicepassword@nats-nats-2.nats-nats1-mgmt.default.svc:6222",
      "nats://natsclusteruser:verynicepassword@nats-nats-3.nats-nats1-mgmt.default.svc:6222"
    ],
    "authorization": {
      "username": "natsclusteruser",
      "password": "verynicepassword",
      "timeout": 1
    }
```