### PR TITLE
Add cluster name configuration to nats.conf

### DIFF
--- a/pkg/conf/natsconf.go
+++ b/pkg/conf/natsconf.go
@@ -35,6 +35,7 @@ type ServerConfig struct {
 }
 
 type ClusterConfig struct {
+        Name          string               `json:"name,omitempty"`
 	Port          int                  `json:"port,omitempty"`
 	Routes        []string             `json:"routes,omitempty"`
 	TLS           *TLSConfig           `json:"tls,omitempty"`

--- a/pkg/conf/natsconf_test.go
+++ b/pkg/conf/natsconf_test.go
@@ -65,6 +65,7 @@ func TestConfMarshal(t *testing.T) {
 				Port:     4222,
 				HTTPPort: 8222,
 				Cluster: &ClusterConfig{
+                                        Name: "my-nats-cluster",
 					Port: 6222,
 				},
 			},
@@ -72,6 +73,7 @@ func TestConfMarshal(t *testing.T) {
   "port": 4222,
   "http_port": 8222,
   "cluster": {
+    "name": "my-nats-cluster",
     "port": 6222
   },
   "logtime": false
@@ -83,6 +85,7 @@ func TestConfMarshal(t *testing.T) {
 				Port:     4222,
 				HTTPPort: 8222,
 				Cluster: &ClusterConfig{
+                                        Name: "my-nats-cluster",
 					Port: 6222,
 					Routes: []string{
 						"nats://nats-1.default.svc:6222",
@@ -95,6 +98,7 @@ func TestConfMarshal(t *testing.T) {
   "port": 4222,
   "http_port": 8222,
   "cluster": {
+    "name": "my-nats-cluster",
     "port": 6222,
     "routes": [
       "nats://nats-1.default.svc:6222",
@@ -113,6 +117,7 @@ func TestConfMarshal(t *testing.T) {
 				Debug:    true,
 				Trace:    true,
 				Cluster: &ClusterConfig{
+                                        Name: "my-nats-cluster",
 					Port: 6222,
 					Routes: []string{
 						"nats://nats-1.default.svc:6222",
@@ -125,6 +130,7 @@ func TestConfMarshal(t *testing.T) {
   "port": 4222,
   "http_port": 8222,
   "cluster": {
+    "name": "my-nats-cluster",
     "port": 6222,
     "routes": [
       "nats://nats-1.default.svc:6222",
@@ -143,6 +149,7 @@ func TestConfMarshal(t *testing.T) {
 				Port:     4222,
 				HTTPPort: 8222,
 				Cluster: &ClusterConfig{
+                                        Name: "my-nats-cluster",
 					Port: 6222,
 					Routes: []string{
 						"nats://nats-1.default.svc:6222",
@@ -160,6 +167,7 @@ func TestConfMarshal(t *testing.T) {
   "port": 4222,
   "http_port": 8222,
   "cluster": {
+    "name": "my-nats-cluster",
     "port": 6222,
     "routes": [
       "nats://nats-1.default.svc:6222",


### PR DESCRIPTION
This PR passes the cluster name to the actual NATS pods nats.conf
Currently, the pods created by the operator are unaware of their cluster name and generate a dynamic cluster name on startup, which sometimes causes issues when rolling out the nodes, eg. after an upgrade.