### PR TITLE
Minor typo fix in one of the examples

### DIFF
--- a/example/leafnode-remotes-gateways.yaml
+++ b/example/leafnode-remotes-gateways.yaml
@@ -26,7 +26,7 @@ spec:
     volumeMounts:
     - name: user-credentials
       mountPath: /etc/nats-creds
-      readOnl: true
+      readOnly: true
 
   leafnodeConfig:
     remotes:


### PR DESCRIPTION
Fixed a small typo in one of the examples. `readOnl:` to `readOnly:`.