### PR TITLE
pkg: add gatewayport and leafnodeport to service

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -276,9 +276,15 @@ func (c *Cluster) checkServices() error {
 		}
 	}
 
-	var websocketPort int
+	var websocketPort, gatewayPort, leafnodePort int
 	if c.cluster.Spec.WebsocketConfig != nil {
 		websocketPort = c.cluster.Spec.WebsocketConfig.Port
+	}
+	if c.cluster.Spec.GatewayConfig != nil {
+		gatewayPort = c.cluster.Spec.GatewayConfig.Port
+	}
+	if c.cluster.Spec.LeafNodeConfig != nil {
+		leafnodePort = c.cluster.Spec.LeafNodeConfig.Port
 	}
 
 	// Create the client service if required.
@@ -315,6 +321,8 @@ func (c *Cluster) checkServices() error {
 			c.cluster.Namespace,
 			c.cluster.AsOwner(),
 			websocketPort,
+			gatewayPort,
+			leafnodePort,
 		)
 		if err != nil {
 			return err

--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -138,6 +138,8 @@ func CreateMgmtService(
 	clusterName, clusterVersion, ns string,
 	owner metav1.OwnerReference,
 	websocketPort int,
+	gatewayPort int,
+	leafnodePort int,
 ) error {
 	ports := []v1.ServicePort{
 		{
@@ -164,6 +166,22 @@ func CreateMgmtService(
 			Name:       "websocket",
 			Port:       int32(websocketPort),
 			TargetPort: intstr.FromInt(websocketPort),
+			Protocol:   v1.ProtocolTCP,
+		})
+	}
+	if gatewayPort > 0 {
+		ports = append(ports, v1.ServicePort{
+			Name:       "gateways",
+			Port:       int32(gatewayPort),
+			TargetPort: intstr.FromInt(gatewayPort),
+			Protocol:   v1.ProtocolTCP,
+		})
+	}
+	if leafnodePort > 0 {
+		ports = append(ports, v1.ServicePort{
+			Name:       "leafnodes",
+			Port:       int32(leafnodePort),
+			TargetPort: intstr.FromInt(leafnodePort),
 			Protocol:   v1.ProtocolTCP,
 		})
 	}


### PR DESCRIPTION
This commit ensures that the gateway and leafnode ports are added to the
management service created for a cluster.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

Plz let me know if these ports should also be added to the client service.
The ports were added to the headless service to match the Helm charts
and raw YAML files, e.g. 
https://github.com/nats-io/k8s/blob/master/helm/charts/nats/templates/service.yaml#L35-L38
Similarly, the port names are pluralized, i.e. `leafnodes` and `gateways`
to match.