### PR TITLE
don't use deprecated TolerateUnreadyEndpointsAnnotation

### DIFF
--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -877,25 +877,19 @@ func newNatsServiceManifest(svcName, clusterName, clusterIP string, ports []v1.S
 	labels[LabelAppKey] = LabelAppValue
 	labels[LabelClusterNameKey] = clusterName
 
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	if tolerateUnready == true {
-		annotations[TolerateUnreadyEndpointsAnnotation] = "true"
-	}
-
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        svcName,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:   svcName,
+			Labels: labels,
 		},
 		Spec: v1.ServiceSpec{
-			Ports:     ports,
-			Selector:  selectors,
-			ClusterIP: clusterIP,
+			Ports:                    ports,
+			Selector:                 selectors,
+			ClusterIP:                clusterIP,
+			PublishNotReadyAddresses: tolerateUnready,
 		},
 	}
+
 	return svc
 }
 


### PR DESCRIPTION
The annotation was deprecated in Kubernetes 1.13, will not be
longer available since 1.24 and only works for the Endpoints
controller.

Use the corresponding Service API field, that is also compatible
with EndpointSlices.

Fixes: https://github.com/nats-io/nats-operator/issues/339