### PR TITLE
change service port name to support Istio explicit protocol selection

### DIFF
--- a/pkg/util/kubernetes/kubernetes.go
+++ b/pkg/util/kubernetes/kubernetes.go
@@ -112,7 +112,7 @@ func CreateClientService(
 ) error {
 	ports := []v1.ServicePort{
 		{
-			Name:       "client",
+			Name:       "tcp-client",
 			Port:       constants.ClientPort,
 			TargetPort: intstr.FromInt(constants.ClientPort),
 			Protocol:   v1.ProtocolTCP,


### PR DESCRIPTION
Kubernetes has a native construct for this called `appProtocol`. Kubernetes
expects either a IANA protocol or a custom protocol prefix with a domain.

I tried setting `appProtocol` to `nats.io/client` but that does not effect
anything Istio, as istio expects only these protocols:
https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection

Setting `appProtocol` to `tcp` probably does work, but tcp is not a valid
iana service name. See:
https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml

Therefor the least intrusive, compatible leaves us with prefixing the service
port name.

Fixes: #88