### PR TITLE
add feature gate to bypass namespace enforcement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: focal
 
 language: go
 go:
-  - "1.16.7"
+  - "1.17.13"
 go_import_path: github.com/nats-io/nats-operator
 
 env:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -107,8 +107,10 @@ func main() {
 	}
 	// Force cluster-scoped instances of nats-operator to run on the "nats-io" namespace.
 	// This is the simplest way to guarantee that leader election occurs as expected because all cluster-scoped instances will do resource locking on this same namespace.
-	if featureMap.IsEnabled(features.ClusterScoped) && namespace != constants.KubernetesNamespaceNatsIO {
-		logrus.Fatalf("cluster-scoped instances of nats-operator must run on the %q namespace", constants.KubernetesNamespaceNatsIO)
+	if featureMap.IsEnabled(features.ClusterScoped) {
+		if !featureMap.IsEnabled(features.BypassNamespaceEnforcement) && namespace != constants.KubernetesNamespaceNatsIO {
+			logrus.Fatalf("cluster-scoped instances of nats-operator must run on the %q namespace", constants.KubernetesNamespaceNatsIO)
+		}
 	}
 
 	if len(local.KubeConfigPath) == 0 {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -29,12 +29,15 @@ type FeatureMap map[Feature]bool
 const (
 	// ClusterScoped is used to indicate whether nats-operator should operate at the namespace or cluster level.
 	ClusterScoped Feature = "ClusterScoped"
+	// BypassNamespaceEnforcement is used to disable the checks that require a cluster-scoped operator to use a fixed namespace.
+	BypassNamespaceEnforcement Feature = "BypassNamespaceEnforcement"
 )
 
 var (
 	// defaultFeatureMap represents the default status of the nats-operator feature gates.
 	defaultFeatureMap = map[Feature]bool{
-		ClusterScoped: false,
+		ClusterScoped:              false,
+		BypassNamespaceEnforcement: false,
 	}
 )
 


### PR DESCRIPTION
This seems to be the only place where this is used, and the comment suggests it's intended to make things easier. It would be nice if there was a way to opt of out this restriction, so this PR adds a way to do that. It's using the same feature-gate mechanism as the `ClusterScoped` option, since that seemed appropriate, but if there's a better place for it, just let me know.

Thanks!